### PR TITLE
Added supplier info in the database

### DIFF
--- a/app/container.py
+++ b/app/container.py
@@ -1,3 +1,4 @@
+from app.services.entity_services.supplier_info_service import SupplierInfoService
 from app.services.mcsd_services.mass_update_consumer_service import (
     MassUpdateConsumerService,
 )
@@ -70,9 +71,12 @@ def container_config(binder: inject.Binder) -> None:
     )
     binder.bind(UpdateConsumerService, update_consumer_service)
 
+    supplier_info_service = SupplierInfoService(db)
+
     mass_update_service = MassUpdateConsumerService(
         update_consumer_service=update_consumer_service,
         supplier_service=supplier_service,
+        supplier_info_service=supplier_info_service,
     )
     scheduler = Scheduler(
         function=mass_update_service.update_all,

--- a/app/db/entities/supplier_info.py
+++ b/app/db/entities/supplier_info.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    String,
+    TIMESTAMP,
+    PrimaryKeyConstraint,
+    Integer,
+    types,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.entities.base import Base
+
+
+class SupplierInfo(Base):
+    __tablename__ = "supplier_info"
+    __table_args__ = (
+        PrimaryKeyConstraint("id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        "id",
+        types.Uuid,
+        nullable=False,
+        default=uuid4,
+    )
+    supplier_id: Mapped[str] = mapped_column(
+        "supplier_id",
+        String,
+        nullable=False,
+    )
+    # How many total sync failures have happened
+    failed_sync_count: Mapped[int] = mapped_column("failed_sync_count", Integer, nullable=False)
+    # How many times the sync has failed in a row
+    failed_attempts: Mapped[int] = mapped_column("failed_attempts", Integer, nullable=False)
+    # The last time the sync succeeded
+    last_success_sync: Mapped[datetime] = mapped_column(
+        "last_success_sync",
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )

--- a/app/db/repositories/supplier_info_repository.py
+++ b/app/db/repositories/supplier_info_repository.py
@@ -1,0 +1,41 @@
+import logging
+
+from sqlalchemy.exc import DatabaseError
+from app.db.decorator import repository
+from app.db.entities.supplier_info import SupplierInfo
+from app.db.repositories.repository_base import RepositoryBase
+
+logger = logging.getLogger(__name__)
+
+
+@repository(SupplierInfo)
+class SupplierInfoRepository(RepositoryBase):
+
+    def get(self, supplier_id: str) -> SupplierInfo:
+        info = self.db_session.session.query(SupplierInfo).filter_by(supplier_id=supplier_id).first()
+        if info is None:
+            info = self.create(supplier_id)
+
+        return info
+
+    def update(self, info: SupplierInfo) -> SupplierInfo:
+        try:
+            self.db_session.add(info)
+            self.db_session.commit()
+            self.db_session.session.refresh(info)
+            return info
+        except DatabaseError as e:
+            self.db_session.rollback()
+            logging.error(f"Failed to update supplier info {info.id}: {e}")
+            raise
+
+    def create(self, supplier_id: str) -> SupplierInfo:
+        try:
+            info = SupplierInfo(supplier_id=supplier_id, failed_sync_count=0, failed_attempts=0)
+            self.db_session.add(info)
+            self.db_session.commit()
+            return info
+        except DatabaseError as e:
+            self.db_session.rollback()
+            logging.error(f"Failed to add suppler info {info.id}: {e}")
+            raise

--- a/app/services/entity_services/supplier_info_service.py
+++ b/app/services/entity_services/supplier_info_service.py
@@ -1,0 +1,22 @@
+import logging
+
+from app.db.db import Database
+from app.db.entities.supplier_info import SupplierInfo
+from app.db.repositories.supplier_info_repository import SupplierInfoRepository
+
+logger = logging.getLogger(__name__)
+
+
+class SupplierInfoService:
+    def __init__(self, database: Database) -> None:
+        self.__database = database
+
+    def get_supplier_info(self, supplier_id: str) -> SupplierInfo:
+        with self.__database.get_db_session() as session:
+            repository = session.get_repository(SupplierInfoRepository)
+            return repository.get(supplier_id)
+
+    def update_supplier_info(self, info: SupplierInfo) -> None:
+        with self.__database.get_db_session() as session:
+            repository = session.get_repository(SupplierInfoRepository)
+            repository.update(info)

--- a/app/services/mcsd_services/mass_update_consumer_service.py
+++ b/app/services/mcsd_services/mass_update_consumer_service.py
@@ -1,8 +1,12 @@
+import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any
 
+from app.services.entity_services.supplier_info_service import SupplierInfoService
 from app.services.entity_services.supplier_service import SupplierService
 from app.services.mcsd_services.update_consumer_service import UpdateConsumerService
+
+logger = logging.getLogger(__name__)
 
 
 class MassUpdateConsumerService:
@@ -10,25 +14,34 @@ class MassUpdateConsumerService:
         self,
         update_consumer_service: UpdateConsumerService,
         supplier_service: SupplierService,
+        supplier_info_service: SupplierInfoService,
     ) -> None:
         self.__supplier_service = supplier_service
         self.__update_consumer_service = update_consumer_service
-        self.__last_update_dict: Dict[str, datetime] = {}
+        self.__supplier_info_service = supplier_info_service
 
     def update_all(self) -> list[dict[str, Any]]:
         all_suppliers = self.__supplier_service.get_all()
         data: list[dict[str, Any]] = []
         for supplier in all_suppliers:
-            last_updated = (
-                self.__last_update_dict[supplier.id]
-                if supplier.id in self.__last_update_dict
-                else None
-            )
+
+            info = self.__supplier_info_service.get_supplier_info(supplier.id)
             new_updated = datetime.now() - timedelta(seconds=60)
-            data.append(
-                self.__update_consumer_service.update_supplier(
-                    supplier.id, last_updated
+            try:
+                data.append(
+                    self.__update_consumer_service.update_supplier(
+                        supplier.id, info.last_success_sync
+                    )
                 )
-            )
-            self.__last_update_dict[supplier.id] = new_updated
+
+                info.last_success_sync = new_updated
+                info.failed_attempts = 0
+                info.last_success_sync = new_updated
+                self.__supplier_info_service.update_supplier_info(info)
+            except Exception as e:
+                logging.error(f"Failed to update supplier {supplier.id}: {e}")
+                info.failed_attempts += 1
+                info.failed_sync_count += 1
+                self.__supplier_info_service.update_supplier_info(info)
+
         return data

--- a/sql/007-supplier_info_table.sql
+++ b/sql/007-supplier_info_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE supplier_info
+(
+  id                uuid       NOT NULL      DEFAULT gen_random_uuid(),
+  supplier_id       VARCHAR    NOT NULL,
+  failed_sync_count INT        NOT NULL      DEFAULT 0,
+  failed_attempts   INT        NOT NULL      DEFAULT 0,
+  last_success_sync TIMESTAMP WITH TIME ZONE DEFAULT (NOW() AT TIME ZONE 'UTC')
+);


### PR DESCRIPTION
Adding supplier fetch information into the database.

- last time successful sync has been done
- how many failed attempts there have been
- how many consecutive failed attempts

This information is used for making sure we always fetch the information from the last known successful pull and could be used for monitoring purposes if needed (ie: prometheus etc)