### PR TITLE
refactor: rework building the adjacency map

### DIFF
--- a/app/models/adjacency/node.py
+++ b/app/models/adjacency/node.py
@@ -1,0 +1,195 @@
+import copy
+from typing import List, Literal
+from fhir.resources.R4B.domainresource import DomainResource
+from pydantic import BaseModel, computed_field
+from fhir.resources.R4B.bundle import BundleEntry, BundleEntryRequest
+
+from app.models.fhir.types import HttpValidVerbs
+from app.models.resource_map.dto import ResourceMapDto, ResourceMapUpdateDto
+from app.services.fhir.references.reference_namespacer import (
+    namespace_resource_reference,
+)
+
+
+class NodeReference(BaseModel):
+    id: str
+    resource_type: str
+
+    def namespace_id(self, namespace: str) -> None:
+        new_id = f"{namespace}-{self.id}"
+        self.id = new_id
+
+
+class SupplierNodeData(BaseModel):
+    supplier_id: str
+    references: List[NodeReference]
+    method: HttpValidVerbs
+    entry: BundleEntry
+
+    @computed_field  # type: ignore
+    @property
+    def hash_value(self) -> int | None:
+        if self.entry.resource is None:
+            return None
+
+        resource = copy.deepcopy(self.entry.resource)
+        namespace_resource_reference(resource, self.supplier_id)
+        resource.meta = None
+        resource.id = None
+
+        return hash(resource.model_dump().__repr__())
+
+
+class ConsumerNodeData(BaseModel):
+    resource: DomainResource | None
+
+    @computed_field  # type: ignore
+    @property
+    def hash_value(self) -> int | None:
+        if self.resource is None:
+            return None
+
+        res = copy.deepcopy(self.resource)
+        res.meta = None
+        res.id = None
+        return hash(res.model_dump().__repr__())
+
+
+class NodeUpdateData(BaseModel):
+    bundle_entry: BundleEntry | None = None
+    resource_map_dto: ResourceMapDto | ResourceMapUpdateDto | None = None
+
+
+class Node(BaseModel):
+    resource_id: str
+    resource_type: str
+    visited: bool = False
+    updated: bool = False
+    supplier_data: SupplierNodeData
+    consumer_data: ConsumerNodeData
+    resource_map: ResourceMapDto | ResourceMapUpdateDto | None = None
+
+    @computed_field  # type: ignore
+    @property
+    def update_status(
+        self,
+    ) -> Literal["ignore", "equal", "delete", "update", "new"]:
+
+        if (
+            self.supplier_data.method == "DELETE"
+            and self.consumer_data.resource is None
+        ):
+            return "ignore"
+
+        if (
+            self.supplier_data.method != "DELETE"
+            and self.supplier_data.hash_value
+            and self.consumer_data.hash_value
+            and self.supplier_data.hash_value == self.consumer_data.hash_value
+        ):
+            return "equal"
+
+        if (
+            self.supplier_data.method == "DELETE"
+            and self.consumer_data.resource is not None
+        ):
+            return "delete"
+
+        if (
+            self.supplier_data.method != "DELETE"
+            and self.supplier_data.hash_value is not None
+            and self.consumer_data.hash_value is None
+            and self.resource_map is None
+        ):
+            return "new"
+
+        return "update"
+
+    @computed_field  # type: ignore
+    @property
+    def update_data(self) -> NodeUpdateData | None:
+        consumer_resource_id = f"{self.supplier_data.supplier_id}-{self.resource_id}"
+        url = f"{self.resource_type}/{consumer_resource_id}"
+        dto: ResourceMapDto | ResourceMapUpdateDto | None = None
+        match self.update_status:
+            case "ignore":
+                return None
+
+            case "equal":
+                return None
+
+            case "delete":
+                entry = BundleEntry.model_construct()
+                entry_request = BundleEntryRequest.model_construct(
+                    method="DELETE", url=url
+                )
+                entry.request = entry_request
+
+                if self.resource_map is None:
+                    raise Exception(
+                        f"Resource map for {self.resource_id} {self.resource_type} cannot be None and marked as delete "
+                    )
+
+                dto = ResourceMapUpdateDto(
+                    history_size=self.resource_map.history_size + 1,
+                    supplier_id=self.supplier_data.supplier_id,
+                    resource_type=self.resource_type,
+                    supplier_resource_id=self.resource_id,
+                )
+
+                return NodeUpdateData(bundle_entry=entry, resource_map_dto=dto)
+
+            case "new":
+                entry = BundleEntry.model_construct()
+                entry_request = BundleEntryRequest.model_construct(
+                    method="PUT", url=url
+                )
+                resource = copy.deepcopy(self.supplier_data.entry.resource)
+                if resource is None:
+                    raise Exception(
+                        f"Resource {self.resource_id} {self.resource_type} cannot be None when a node is marked `new`"
+                    )
+                namespace_resource_reference(resource, self.supplier_data.supplier_id)
+                resource.id = consumer_resource_id
+                entry.resource = resource
+                entry.request = entry_request
+
+                dto = ResourceMapDto(
+                    supplier_id=self.supplier_data.supplier_id,
+                    supplier_resource_id=self.resource_id,
+                    consumer_resource_id=consumer_resource_id,
+                    resource_type=self.resource_type,
+                    history_size=1,
+                )
+
+                return NodeUpdateData(bundle_entry=entry, resource_map_dto=dto)
+
+            case "update":
+                entry = BundleEntry.model_construct()
+                entry_request = BundleEntryRequest.model_construct(
+                    method="PUT", url=url
+                )
+                resource = copy.deepcopy(self.supplier_data.entry.resource)
+                if resource is None:
+                    raise Exception(
+                        f"Resource {self.resource_id} {self.resource_type} cannot be None and node marked as `update`"
+                    )
+
+                namespace_resource_reference(resource, self.supplier_data.supplier_id)
+                resource.id = consumer_resource_id
+                entry.request = entry_request
+                entry.resource = resource
+
+                if self.resource_map is None:
+                    raise Exception(
+                        f"Resource map for {self.resource_id} {self.resource_type} cannot be None and marked as `update`"
+                    )
+
+                dto = ResourceMapUpdateDto(
+                    supplier_id=self.supplier_data.supplier_id,
+                    supplier_resource_id=self.resource_id,
+                    resource_type=self.resource_type,
+                    history_size=self.resource_map.history_size + 1,
+                )
+
+                return NodeUpdateData(bundle_entry=entry, resource_map_dto=dto)

--- a/app/services/fhir/bundle/bunlde_parser.py
+++ b/app/services/fhir/bundle/bunlde_parser.py
@@ -9,7 +9,7 @@ from fhir.resources.R4B.bundle import (
 )
 from pydantic import ValidationError
 
-from app.models.adjacency.adjacency_map import AdjacencyReference
+from app.models.adjacency.node import NodeReference
 from app.services.fhir.model_factory import create_resource
 
 
@@ -98,8 +98,7 @@ def create_bundle(data: Dict[str, Any] | None = None, strict: bool = False) -> B
         raise e
 
 
-def create_bundle_request(data: list[AdjacencyReference]) -> Bundle:
-
+def create_bundle_request(data: list[NodeReference]) -> Bundle:
     request_bundle = Bundle.model_construct(type="batch")
     request_bundle.entry = []
     for ref in data:
@@ -113,7 +112,6 @@ def create_bundle_request(data: list[AdjacencyReference]) -> Bundle:
     return request_bundle
 
 
-# TODO: change name and put in fhir service
 def get_entries_from_bundle_of_bundles(data: Bundle) -> List[BundleEntry]:
     entries = data.entry if data.entry else []
     results: List[BundleEntry] = []

--- a/app/services/fhir/fhir_service.py
+++ b/app/services/fhir/fhir_service.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 from fhir.resources.R4B.bundle import BundleEntry, Bundle
 from fhir.resources.R4B.domainresource import DomainResource
 from fhir.resources.R4B.reference import Reference
-from app.models.adjacency.adjacency_map import AdjacencyReference
+from app.models.adjacency.node import NodeReference
 from app.models.fhir.types import HttpValidVerbs
 from app.services.fhir.bundle.bundle_utils import (
     filter_history_entries,
@@ -91,7 +91,7 @@ class FhirService:
         """
         return filter_history_entries(entries)
 
-    def create_bundle_request(self, data: List[AdjacencyReference]) -> Bundle:
+    def create_bundle_request(self, data: List[NodeReference]) -> Bundle:
         """
         Takes a list of AdjacencyReference and creates a Bundle with GET as an HTTP request method
         """

--- a/app/services/fhir/model_factory.py
+++ b/app/services/fhir/model_factory.py
@@ -10,7 +10,6 @@ from fhir.resources.R4B.practitionerrole import PractitionerRole
 from fhir.resources.R4B.healthcareservice import HealthcareService
 from pydantic import ValidationError
 
-
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=DomainResource)

--- a/app/services_new/adjacency_map_service.py
+++ b/app/services_new/adjacency_map_service.py
@@ -1,14 +1,13 @@
-from collections import deque
-from typing import List, Deque
+from typing import List
 from fhir.resources.R4B.bundle import BundleEntry
-from app.models.adjacency.adjacency_map import (
-    AdjacencyMap,
-    Node,
-    AdjacencyReference,
-    SupplierNodeData,
-    ConsumerNodeData,
-)
 
+from app.models.adjacency.adjacency_map import AdjacencyData, AdjacencyMap
+from app.models.adjacency.node import (
+    ConsumerNodeData,
+    Node,
+    NodeReference,
+    SupplierNodeData,
+)
 from app.models.resource_map.dto import ResourceMapDto
 from app.services.entity_services.resource_map_service import ResourceMapService
 from app.services.fhir.fhir_service import FhirService
@@ -30,22 +29,32 @@ class AdjacencyMapService:
         self.__consumer_api = consumer_api
         self.__resource_map_service = resource_map_service
 
-    def create_supplier_data(
-        self, supplier_id: str, entry: BundleEntry
-    ) -> SupplierNodeData:
-        method = self.__fhir_service.get_request_method_from_entry(entry)
-        refs = []
-        if entry.resource:
-            res_refs = self.__fhir_service.get_references(entry.resource)
-            for ref in res_refs:
-                res_type, ref_id = self.__fhir_service.split_reference(ref)
-                refs.append(AdjacencyReference(id=ref_id, resource_type=res_type))
-        return SupplierNodeData(
-            supplier_id=supplier_id,
-            method=method,
-            references=refs,
-            entry=entry,
+    def build_adjacency_map(
+        self, entries: List[BundleEntry], updated_ids: List[str] | None = None
+    ) -> AdjacencyMap:
+        nodes = [self.create_node(entry) for entry in entries]
+        adj_map = AdjacencyMap(nodes, updated_ids)
+        missing_refs = adj_map.get_missing_refs()
+        while missing_refs:
+            missing_entries = self.get_entries(missing_refs, self.__supplier_api)
+            missing_nodes = [self.create_node(entry) for entry in missing_entries]
+            adj_map.add_nodes(missing_nodes)
+            missing_refs = adj_map.get_missing_refs()
+
+        self.get_consumer_data(adj_map.data)
+
+        return adj_map
+
+    def get_entries(
+        self, refs: List[NodeReference], fhir_api: FhirApi
+    ) -> List[BundleEntry]:
+        bundle_request = self.__fhir_service.create_bundle_request(refs)
+        res = self.__fhir_service.filter_history_entries(
+            self.__fhir_service.get_entries_from_bundle_of_bundles(
+                fhir_api.post_bundle(bundle_request)
+            )
         )
+        return res
 
     def create_node(self, entry: BundleEntry) -> Node:
         res_type, id = self.__fhir_service.get_resource_type_and_id_from_entry(entry)
@@ -67,82 +76,32 @@ class AdjacencyMapService:
         )
         return node
 
-    def add_node(self, adj_map: AdjacencyMap, node: Node) -> None:
-        if node.resource_id in adj_map.keys():
-            return
-
-        adj_map[node.resource_id] = node
-
-    def build_adjacency_map(
-        self, entries: List[BundleEntry], updated_ids: List[str] | None = None
-    ) -> AdjacencyMap:
-        ids = deque(
-            [
-                self.__fhir_service.get_resource_type_and_id_from_entry(entry)[1]
-                for entry in entries
-            ]
+    def create_supplier_data(
+        self, supplier_id: str, entry: BundleEntry
+    ) -> SupplierNodeData:
+        method = self.__fhir_service.get_request_method_from_entry(entry)
+        refs = []
+        if entry.resource:
+            res_refs = self.__fhir_service.get_references(entry.resource)
+            for ref in res_refs:
+                res_type, ref_id = self.__fhir_service.split_reference(ref)
+                refs.append(NodeReference(id=ref_id, resource_type=res_type))
+        return SupplierNodeData(
+            supplier_id=supplier_id,
+            method=method,
+            references=refs,
+            entry=entry,
         )
-        nodes = [self.create_node(entry) for entry in entries]
-        adj_map: AdjacencyMap = dict(zip(ids, nodes))
 
-        processed = []
-        while ids:
-            id = ids.popleft()
-            node = adj_map[id]
-            processed.append(id)
-
-            # take care of missing resources from list
-            missing_ids = []
-            for ref in node.supplier_data.references:
-                if ref.id not in ids:
-                    missing_ids.append(ref)
-
-            if len(missing_ids) > 0:
-                bundle_request = self.__fhir_service.create_bundle_request(missing_ids)
-                res = self.__fhir_service.filter_history_entries(
-                    self.__fhir_service.get_entries_from_bundle_of_bundles(
-                        self.__supplier_api.post_bundle(bundle_request)
-                    )
-                )
-                for e in res:
-                    missing_node = self.create_node(e)
-                    if missing_node.resource_id not in processed:
-                        self.add_node(adj_map, missing_node)
-                        ids.append(missing_node.resource_id)
-                        # mark as processed
-                        processed.append(missing_node.resource_id)
-
-            # take care of existing references
-            for ref in node.supplier_data.references:
-                silbing = adj_map[ref.id]
-                if silbing.resource_id not in processed:
-                    processed.append(silbing.resource_id)
-
-        # mark ids from previous runs as processed
-        if updated_ids is not None:
-            for id in updated_ids:
-                if id in adj_map.keys():
-                    adj_map[id].updated = True
-
-        # get consumer data for adj list:
-        self.get_consumer_data(adj_map)
-
-        return adj_map
-
-    def get_consumer_data(self, adj_map: AdjacencyMap) -> None:
+    def get_consumer_data(self, adj_map: AdjacencyData) -> None:
         consumer_targets = [
-            AdjacencyReference(
+            NodeReference(
                 id=f"{self.supplier_id}-{node.resource_id}",
                 resource_type=node.resource_type,
             )
             for node in adj_map.values()
         ]
-        consumer_bunlde = self.__fhir_service.create_bundle_request(consumer_targets)
-        res = self.__fhir_service.filter_history_entries(
-            self.__fhir_service.get_entries_from_bundle_of_bundles(
-                self.__consumer_api.post_bundle(consumer_bunlde)
-            )
-        )
+        res = self.get_entries(consumer_targets, self.__consumer_api)
         for entry in res:
             _, id = self.__fhir_service.get_resource_type_and_id_from_entry(entry)
             if id is not None:
@@ -151,22 +110,3 @@ class AdjacencyMapService:
                 node.consumer_data = ConsumerNodeData(
                     resource=entry.resource,
                 )
-
-    def bfs(self, adj_map: AdjacencyMap, node: Node) -> List[Node]:
-        queue: Deque["Node"] = deque()
-        group = []
-
-        node.visited = True
-        queue.append(node)
-        group.append(node)
-
-        while queue:
-            current = queue.popleft()
-            for ref in current.supplier_data.references:
-                sibling = adj_map[ref.id]
-                if sibling.visited is False:
-                    sibling.visited = True
-                    queue.append(sibling)
-                    group.append(sibling)
-
-        return group

--- a/app/services_new/update_service.py
+++ b/app/services_new/update_service.py
@@ -8,8 +8,7 @@ from uuid import uuid4
 from fhir.resources.R4B.bundle import Bundle, BundleEntry
 from yarl import URL
 from app.models.resource_map.dto import ResourceMapDto, ResourceMapUpdateDto
-from app.models.adjacency.adjacency_map import (
-    AdjacencyMap,
+from app.models.adjacency.node import (
     Node,
 )
 from app.models.supplier.dto import SupplierDto
@@ -122,17 +121,15 @@ class UpdateConsumer:
         self, entries: List[BundleEntry], adjacency_map_service: AdjacencyMapService
     ) -> List[Node]:
         updated = []
-        adj_map: AdjacencyMap = adjacency_map_service.build_adjacency_map(
-            entries, self.__cache
-        )
-        for node in adj_map.values():
+        adj_map = adjacency_map_service.build_adjacency_map(entries, self.__cache)
+        for node in adj_map.data.values():
             if node.updated is True:
                 logger.info(
                     f"Item {node.resource_id} {node.resource_type} has been processed earlier, skipping..."
                 )
                 continue
 
-            group = adjacency_map_service.bfs(adj_map, node)
+            group = adj_map.get_group(node)
             results = self.update_with_bundle(group)
             updated.extend(results)
 


### PR DESCRIPTION
- Simplify the creation of the `AdjacencyMap`.
- Simplify the process of fetching missing nodes during the creation of `AdjacencyMap`.
- Split of responsibilities between modifying the map itself and making HTTP calls to fetch the required data for it. 