### PR TITLE
Set postgres version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         needs: build
         services:
           postgres:
-            image: postgres:14
+            image: postgres:15
             env:
               POSTGRES_USER: postgres
               POSTGRES_PASSWORD: postgres

--- a/example-setup-with-hapi/docker-compose.yaml
+++ b/example-setup-with-hapi/docker-compose.yaml
@@ -96,7 +96,7 @@ services:
     command: sleep infinity
   
   postgres:
-    image: postgres
+    image: postgres:15
     healthcheck:
       test: ["CMD-SHELL", "pg_isready --user postgres"]
       start_period: 30s


### PR DESCRIPTION
When there is no version set, the latest version that you have pulled locally is used. The db volume is persistent and if the postgres version changes you will see an error that the data in the volume is not compatible with the postgres version.

Currently we are using Postgres 15.x. Checked with OPS.

With this change, it is possible that you will need to docker compose down -v to delete the persistent volumes and run docker compose up -d again.