### PR TITLE
Add supplier deletion logic

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,6 +29,9 @@ class Scheduler(BaseModel):
     automatic_background_cleanup: bool = Field(default=True)
     directory_stale_timeout: str
     cleanup_client_directory_after_success_timeout: str
+    cleanup_client_directory_after_directory_delete: bool = Field(
+        default=True,
+    )
 
     @computed_field
     def delay_input_in_sec(self) -> int:

--- a/app/container.py
+++ b/app/container.py
@@ -1,6 +1,6 @@
-from app.services.entity.ignored_directory_service import (
-    IgnoredDirectoryService,
-)
+from app.services.entity.ignored_directory_service import IgnoredDirectoryService
+from app.services.entity.directory_cache_service import DirectoryCacheService
+
 from app.services.entity.directory_info_service import DirectoryInfoService
 from app.services.directory_provider.factory import DirectoryProviderFactory
 from app.services.directory_provider.directory_provider import DirectoryProvider
@@ -58,6 +58,8 @@ def container_config(binder: inject.Binder) -> None:
     )
     binder.bind(DirectoryInfoService, directory_info_service)
 
+    directory_cache_service = DirectoryCacheService(db)
+
     update_all_service = MassUpdateClientService(
         update_client_service=update_service,
         directory_provider=directory_provider,
@@ -65,6 +67,8 @@ def container_config(binder: inject.Binder) -> None:
         ignored_directory_service=ignored_directory_service,
         cleanup_client_directory_after_success_timeout_seconds=config.scheduler.cleanup_client_directory_after_success_timeout_in_sec,  # type: ignore
         stats=get_stats(),
+        directory_cache_service=directory_cache_service,
+        cleanup_client_directory_after_directory_delete=config.scheduler.cleanup_client_directory_after_directory_delete,
     )
 
     update_scheduler = Scheduler(

--- a/app/db/repositories/directory_cache_repository.py
+++ b/app/db/repositories/directory_cache_repository.py
@@ -13,6 +13,11 @@ logger = logging.getLogger(__name__)
 @repository(DirectoryCache)
 class DirectoryCacheRepository(RepositoryBase):
 
+    def get_deleted_directories(self) -> Sequence[DirectoryCache]:
+        query = select(DirectoryCache).where(DirectoryCache.is_deleted)
+        caches = self.db_session.session.execute(query).scalars().all()
+        return caches
+
     def get(self, directory_id: str, with_deleted: bool = False) -> DirectoryCache | None:
         query = select(DirectoryCache).where(DirectoryCache.directory_id == directory_id)
         if not with_deleted:

--- a/app/services/directory_provider/caching_provider.py
+++ b/app/services/directory_provider/caching_provider.py
@@ -69,12 +69,12 @@ class CachingDirectoryProvider(DirectoryProvider):
 
         for original_directory in original_directories:
             if original_directory.id not in [directory.id for directory in directories]:
-                if self.__directoryProvider.check_if_directory_is_deleted(directory.id):
+                if self.__directoryProvider.check_if_directory_is_deleted(original_directory.id):
                     self.__directory_cache_service.set_directory_cache(
                         DirectoryDto(
-                            id=directory.id,
-                            name=directory.name,
-                            endpoint=directory.endpoint,
+                            id=original_directory.id,
+                            name=original_directory.name,
+                            endpoint=original_directory.endpoint,
                             is_deleted=True,
                         )
                     )

--- a/app/services/entity/directory_cache_service.py
+++ b/app/services/entity/directory_cache_service.py
@@ -10,6 +10,13 @@ class DirectoryCacheService:
     def __init__(self, database: Database) -> None:
         self.__database = database
 
+    def get_deleted_directories(self) -> list[DirectoryDto]:
+        with self.__database.get_db_session() as session:
+            repository = session.get_repository(DirectoryCacheRepository)
+            deleted_directories = repository.get_deleted_directories()
+            return [self._hydrate_to_directory_dto(directory) for directory in deleted_directories]
+
+
     def get_directory_cache(self, directory_id: str, with_deleted: bool = False) -> DirectoryDto|None:
         with self.__database.get_db_session() as session:
             repository = session.get_repository(DirectoryCacheRepository)

--- a/app/services/entity/directory_info_service.py
+++ b/app/services/entity/directory_info_service.py
@@ -14,6 +14,14 @@ class DirectoryInfoService:
         self.__database = database
         self.__directory_stale_timeout_seconds = directory_stale_timeout_seconds
 
+    def delete_directory_info(self, directory_id: str) -> None:
+        with self.__database.get_db_session() as session:
+            repository = session.get_repository(DirectoryInfoRepository)
+            info = repository.get(directory_id)
+            session.delete(info)
+            session.commit()
+
+
     def get_directory_info(self, directory_id: str) -> DirectoryInfo:
         with self.__database.get_db_session() as session:
             repository = session.get_repository(DirectoryInfoRepository)

--- a/example-setup-with-hapi/app.conf
+++ b/example-setup-with-hapi/app.conf
@@ -30,6 +30,8 @@ automatic_background_update = True
 automatic_background_cleanup = True
 directory_stale_timeout = 120s
 cleanup_client_directory_after_success_timeout = 30d
+cleanup_client_directory_after_directory_delete = True
+
 
 [telemetry]
 enabled = False

--- a/example-setup-with-hapi/client.application.yaml
+++ b/example-setup-with-hapi/client.application.yaml
@@ -24,3 +24,4 @@ hapi:
     allow_multiple_delete: true
     allow_expunge: true
     delete_expunge_enabled: true
+    allow_cascading_deletes: true

--- a/tests/services/update/test_mass_update_client_service.py
+++ b/tests/services/update/test_mass_update_client_service.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta, timezone
+from app.services.entity.directory_cache_service import DirectoryCacheService
 from app.services.entity.directory_info_service import DirectoryInfoService
 from app.services.update.mass_update_client_service import MassUpdateClientService
 from app.db.entities.directory_info import DirectoryInfo
@@ -34,6 +35,8 @@ def test_cleanup_old_directories(directory_info_service: DirectoryInfoService) -
         ignored_directory_service=mock_ignored_directory_service,
         cleanup_client_directory_after_success_timeout_seconds=3600, # less than 2 hours
         stats=NoopStats(),
+        directory_cache_service=MagicMock(spec=DirectoryCacheService),  # Mocking the directory cache service
+        cleanup_client_directory_after_directory_delete=True,
     )
 
     service.cleanup_old_directories()

--- a/tests/services/update/test_update_client_service.py
+++ b/tests/services/update/test_update_client_service.py
@@ -28,11 +28,13 @@ def test_cleanup() -> None:
                 directory_id=directory_id,
                 update_client_resource_id="resource_1",
                 resource_type=resource_type,
+                directory_resource_id="directory_resource_1",
             ),
             MagicMock(
                 directory_id=directory_id,
                 update_client_resource_id="resource_2",
                 resource_type=resource_type,
+                directory_resource_id="directory_resource_2",
             ),
         ]
 
@@ -76,4 +78,4 @@ def test_cleanup() -> None:
         assert called_bundle.entry[0].request.url is not None
         split = called_bundle.entry[0].request.url.split("/")
         assert split[0] == resource.value
-        assert split[1] == "resource_1" or split[1] == "resource_2"
+        assert split[1] == "resource_1?_cascade=delete" or split[1] == "resource_2?_cascade=delete"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,7 @@ def get_test_config() -> Config:
             max_logs_entries=10,
             directory_stale_timeout="120s",
             cleanup_client_directory_after_success_timeout="3d",
+            cleanup_client_directory_after_directory_delete=True,
         ),
         external_cache=ConfigExternalCache(),
     )


### PR DESCRIPTION
- Introduced cleanup_client_directory_after_supplier_delete option in Scheduler model.
- Implemented get_deleted_suppliers method in SupplierCacheRepository and SupplierCacheService.
- Updated MassUpdateConsumerService to clean up deleted suppliers based on configuration.
- Added delete_supplier_info method in SupplierInfoService for supplier info deletion.
- Modified configuration files to include new options for supplier deletion handling.

For the ticket in #128 the only part that is missing is marking resources for deletion. Could be added in a separate issue, depending on the actual need for it. Skipped it for now since it requires some big reprogramming, not sure if worth the time.

https://github.com/minvws/gfmodules-coordination-private/pull/564#issue-3191706576

### DoD
- [x]  Delete data when supplier is down for configured time
- [x]  Delete data when a supplier is removed from the supplier API
- [ ]  Mark them for 'deletion' at a specific time in the name property of the resource
- [x]  Delete all resources after a specific time 
- [x]  Create Config variable