### PR TITLE
Fix directory cleanup logic

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,15 +23,17 @@ class ConfigApp(BaseModel):
 
 
 class Scheduler(BaseModel):
-    delay_input: str
-    max_logs_entries: int
+    delay_input: str = Field(default="30s")
+    max_logs_entries: int = Field(default=1000, ge=0)
     automatic_background_update: bool = Field(default=True)
     automatic_background_cleanup: bool = Field(default=True)
-    directory_stale_timeout: str
-    cleanup_client_directory_after_success_timeout: str
+    directory_stale_timeout: str = Field(default="5m")
+    cleanup_client_directory_after_success_timeout: str = Field(default="30d")
     cleanup_client_directory_after_directory_delete: bool = Field(
         default=True,
     )
+    ignore_directory_after_success_timeout: str = Field(default="10m")
+    ignore_directory_after_failed_attempts_threshold: int = Field(default=20)
 
     @computed_field
     def delay_input_in_sec(self) -> int:
@@ -44,6 +46,10 @@ class Scheduler(BaseModel):
     @computed_field
     def cleanup_client_directory_after_success_timeout_in_sec(self) -> int:
         return self._convert_to_sec(self.cleanup_client_directory_after_success_timeout)
+    
+    @computed_field
+    def ignore_directory_after_success_timeout_in_sec(self) -> int:
+        return self._convert_to_sec(self.ignore_directory_after_success_timeout)
 
     def _convert_to_sec(self, value: str) -> int:
         conversion_map = {"s": 1, "m": 60, "h": 3600, "d": 86400}

--- a/app/container.py
+++ b/app/container.py
@@ -69,6 +69,8 @@ def container_config(binder: inject.Binder) -> None:
         stats=get_stats(),
         directory_cache_service=directory_cache_service,
         cleanup_client_directory_after_directory_delete=config.scheduler.cleanup_client_directory_after_directory_delete,
+        ignore_directory_after_success_timeout_seconds=config.scheduler.ignore_directory_after_success_timeout_in_sec,  # type: ignore
+        ignore_directory_after_failed_attempts_threshold=config.scheduler.ignore_directory_after_failed_attempts_threshold,
     )
 
     update_scheduler = Scheduler(

--- a/app/services/update/adjacency_map_service.py
+++ b/app/services/update/adjacency_map_service.py
@@ -66,11 +66,7 @@ class AdjacencyMapService:
 
         for entry in update_client_entries:
             _, id = self.__fhir_service.get_resource_type_and_id_from_entry(entry)
-            print("\n#####@@@@@@@@@###########")
-            print(id)
             res_id = id.replace(f"{self.directory_id}-", "")
-            print(res_id)
-            print("#####@@@@@@@@@###########\n")
             node = adj_map.data[res_id]
             node.update_client_hash = self.__computation_service.hash_update_client_entry(entry)
 

--- a/example-setup-with-hapi/app.conf
+++ b/example-setup-with-hapi/app.conf
@@ -25,12 +25,14 @@ default_cache_namespace = mcsd
 
 [scheduler]
 delay_input = 30s
-max_logs_entries = 100
+max_logs_entries = 1000
 automatic_background_update = True
 automatic_background_cleanup = True
-directory_stale_timeout = 120s
+directory_stale_timeout = 5m
 cleanup_client_directory_after_success_timeout = 30d
 cleanup_client_directory_after_directory_delete = True
+ignore_directory_after_success_timeout = 10m
+ignore_directory_after_failed_attempts_threshold = 20
 
 
 [telemetry]

--- a/example-setup-with-hapi/app.conf.example
+++ b/example-setup-with-hapi/app.conf.example
@@ -16,15 +16,22 @@ pool_recycle=1800
 # delay time for scheduled update to run, value should be number with a unit of time (only s, m, h)
 delay_input = 30s
 # maximum number of entries in logs
-max_logs_entries = 100
+max_logs_entries = 1000
 # background updates automatically start on bootstrap
 automatic_background_update = True
 # background cleanup automatically start on bootstrap
 automatic_background_cleanup = True
-# Time it takes after the last successful update before an directory is marked as unhealthy
-directory_stale_timeout = 120s
-# Delay time for scheduled clean up to run
+# Time it takes after the last successful update before a directory is marked as unhealthy
+directory_stale_timeout = 5m
+# Ignore directories that have not been updated successfully for a certain time
+ignore_directory_after_success_timeout = 10m
+# Clean up (delete data from directory) when directory has not been updated successfully for a certain time
 cleanup_client_directory_after_success_timeout = 30d
+# Clean up (delete data from directory) when directory is deleted
+cleanup_client_directory_after_directory_delete = True
+# Number of consecutive failed update attempts before a directory is ignored
+ignore_directory_after_failed_attempts_threshold = 20
+
 [telemetry]
 # Telemetry is enabled or not
 enabled = False

--- a/tests/services/update/test_mass_update_client_service.py
+++ b/tests/services/update/test_mass_update_client_service.py
@@ -1,53 +1,372 @@
 from unittest.mock import MagicMock
 from datetime import datetime, timedelta, timezone
+import pytest
 from app.services.entity.directory_cache_service import DirectoryCacheService
-from app.services.entity.directory_info_service import DirectoryInfoService
 from app.services.update.mass_update_client_service import MassUpdateClientService
 from app.db.entities.directory_info import DirectoryInfo
+from app.models.directory.dto import DirectoryDto
 from app.stats import NoopStats
 
 
+@pytest.fixture
+def mock_update_client_service() -> MagicMock:
+    return MagicMock()
 
-def test_cleanup_old_directories(directory_info_service: DirectoryInfoService) -> None:
-    mock_update_client_service = MagicMock()
-    mock_directory_provider = MagicMock()
-    mock_directory_info_service = MagicMock()
-    mock_ignored_directory_service = MagicMock()
 
-    mock_outdated_directory_info = DirectoryInfo(
+@pytest.fixture
+def mock_directory_provider() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_directory_info_service() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_ignored_directory_service() -> MagicMock:
+    mock = MagicMock()
+    mock.get_ignored_directory.return_value = None
+    return mock
+
+
+@pytest.fixture
+def mock_directory_cache_service() -> MagicMock:
+    mock = MagicMock(spec=DirectoryCacheService)
+    mock.get_deleted_directories.return_value = []
+    return mock
+
+
+@pytest.fixture
+def mass_update_client_service(
+    mock_update_client_service: MagicMock,
+    mock_directory_provider: MagicMock, 
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+) -> MassUpdateClientService:
+    return MassUpdateClientService(
+        update_client_service=mock_update_client_service,
+        directory_provider=mock_directory_provider,
+        directory_info_service=mock_directory_info_service,
+        ignored_directory_service=mock_ignored_directory_service,
+        directory_cache_service=mock_directory_cache_service,
+        cleanup_client_directory_after_success_timeout_seconds=3600,
+        stats=NoopStats(),
+        cleanup_client_directory_after_directory_delete=True,
+        ignore_directory_after_success_timeout_seconds=3600,
+        ignore_directory_after_failed_attempts_threshold=5,
+    )
+
+
+@pytest.fixture
+def outdated_directory() -> DirectoryInfo:
+    return DirectoryInfo(
         directory_id="outdated_directory",
-        last_success_sync=datetime.now(timezone.utc) - timedelta(hours=2), # more than 1 hour
+        last_success_sync=datetime.now(timezone.utc) - timedelta(hours=2),
         failed_attempts=0,
         failed_sync_count=0,
     )
-    mock_success_directory_info = DirectoryInfo(
-        directory_id="directory_1",
-        last_success_sync=datetime.now(timezone.utc) - timedelta(minutes=30), # Less than 1 hour
+
+
+@pytest.fixture
+def recent_directory() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="recent_directory",
+        last_success_sync=datetime.now(timezone.utc) - timedelta(minutes=30),
         failed_attempts=0,
         failed_sync_count=0,
     )
-    mock_directory_info_service.get_all_directories_info.return_value = [mock_outdated_directory_info, mock_success_directory_info]
+
+
+@pytest.fixture
+def never_synced_directory_high_failures() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="never_synced_directory",
+        last_success_sync=None,
+        failed_attempts=6,
+        failed_sync_count=10,
+    )
+
+
+@pytest.fixture
+def never_synced_directory_low_failures() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="never_synced_directory",
+        last_success_sync=None,
+        failed_attempts=3,
+        failed_sync_count=5,
+    )
+
+
+@pytest.fixture
+def mixed_scenario_directories() -> list[DirectoryInfo]:
+    return [
+        DirectoryInfo(
+            directory_id="very_old_directory",
+            last_success_sync=datetime.now(timezone.utc) - timedelta(hours=3),
+            failed_attempts=0,
+            failed_sync_count=0,
+        ),
+        DirectoryInfo(
+            directory_id="old_directory",
+            last_success_sync=datetime.now(timezone.utc) - timedelta(minutes=75),
+            failed_attempts=0,
+            failed_sync_count=0,
+        ),
+        DirectoryInfo(
+            directory_id="recent_directory",
+            last_success_sync=datetime.now(timezone.utc) - timedelta(minutes=30),
+            failed_attempts=0,
+            failed_sync_count=0,
+        ),
+        DirectoryInfo(
+            directory_id="never_synced",
+            last_success_sync=None,
+            failed_attempts=5,
+            failed_sync_count=10,
+        ),
+    ]
+
+
+@pytest.fixture
+def already_ignored_failed_directory() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="already_ignored_failed_directory",
+        last_success_sync=None,
+        failed_attempts=10,
+        failed_sync_count=15,
+    )
+
+
+@pytest.fixture
+def single_deleted_directory() -> list[DirectoryDto]:
+    return [
+        DirectoryDto(id="deleted_directory", name="Deleted", endpoint="http://deleted.com", is_deleted=True),
+    ]
+
+
+@pytest.fixture
+def never_synced_directory_threshold_failures() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="never_synced_directory",
+        last_success_sync=None,
+        failed_attempts=5,
+        failed_sync_count=10,
+    )
+
+
+@pytest.fixture
+def directory_to_ignore_only() -> DirectoryInfo:
+    return DirectoryInfo(
+        directory_id="directory_to_ignore",
+        last_success_sync=datetime.now(timezone.utc) - timedelta(minutes=75),
+        failed_attempts=0,
+        failed_sync_count=0,
+    )
+
+
+@pytest.fixture
+def deleted_directories() -> list[DirectoryDto]:
+    return [
+        DirectoryDto(id="deleted_1", name="Deleted 1", endpoint="http://deleted1.com", is_deleted=True),
+        DirectoryDto(id="deleted_2", name="Deleted 2", endpoint="http://deleted2.com", is_deleted=True),
+    ]
+
+
+def test_cleanup_old_directories_ignores_and_cleans_outdated_directories(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_update_client_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+    outdated_directory: DirectoryInfo,
+    recent_directory: DirectoryInfo
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = [outdated_directory, recent_directory]
+
+    mass_update_client_service.cleanup_old_directories()
+
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_called_once_with("outdated_directory")
+    mock_update_client_service.cleanup.assert_called_once_with("outdated_directory")
+    mock_directory_info_service.delete_directory_info.assert_called_once_with("outdated_directory")
+    mock_directory_cache_service.delete_directory_cache.assert_called_once_with("outdated_directory")
+
+
+def test_cleanup_old_directories_does_not_ignore_already_ignored_directories(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_update_client_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+    outdated_directory: DirectoryInfo
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = [outdated_directory]
+    mock_ignored_directory_service.get_ignored_directory.return_value = MagicMock()
+
+    mass_update_client_service.cleanup_old_directories()
+
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_not_called()
+    mock_update_client_service.cleanup.assert_called_once_with("outdated_directory")
+
+
+def test_cleanup_old_directories_only_ignores_when_exceeding_ignore_timeout(
+    mock_update_client_service: MagicMock,
+    mock_directory_provider: MagicMock,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+    directory_to_ignore_only: DirectoryInfo
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = [directory_to_ignore_only]
 
     service = MassUpdateClientService(
         update_client_service=mock_update_client_service,
         directory_provider=mock_directory_provider,
         directory_info_service=mock_directory_info_service,
         ignored_directory_service=mock_ignored_directory_service,
-        cleanup_client_directory_after_success_timeout_seconds=3600, # less than 2 hours
+        cleanup_client_directory_after_success_timeout_seconds=7200,
         stats=NoopStats(),
-        directory_cache_service=MagicMock(spec=DirectoryCacheService),  # Mocking the directory cache service
+        directory_cache_service=mock_directory_cache_service,
         cleanup_client_directory_after_directory_delete=True,
+        ignore_directory_after_success_timeout_seconds=3600,
+        ignore_directory_after_failed_attempts_threshold=5,
     )
 
     service.cleanup_old_directories()
 
-    mock_directory_info_service.get_all_directories_info.assert_called_once()
-    mock_update_client_service.cleanup.assert_called_once_with("outdated_directory") # It should only call cleanup for the directory that is older than 1 hour
-    mock_ignored_directory_service.add_directory_to_ignore_list.assert_called_once_with("outdated_directory")
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_called_once_with("directory_to_ignore")
+    mock_update_client_service.cleanup.assert_not_called()
 
-    # it is now ignored, so it should not be updated on the next call
+
+def test_cleanup_old_directories_ignores_directories_with_failed_attempts_threshold(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_update_client_service: MagicMock,
+    never_synced_directory_high_failures: DirectoryInfo,
+    never_synced_directory_low_failures: DirectoryInfo,
+    never_synced_directory_threshold_failures: DirectoryInfo
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = [
+        never_synced_directory_high_failures, 
+        never_synced_directory_low_failures,
+        never_synced_directory_threshold_failures
+    ]
+
+    mass_update_client_service.cleanup_old_directories()
+
+    assert mock_ignored_directory_service.add_directory_to_ignore_list.call_count == 2
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_any_call("never_synced_directory")
+    mock_update_client_service.cleanup.assert_not_called()
+
+
+def test_cleanup_old_directories_cleans_deleted_directories_from_cache(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+    mock_update_client_service: MagicMock,
+    deleted_directories: list[DirectoryDto]
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = []
+    mock_directory_cache_service.get_deleted_directories.return_value = deleted_directories
+
+    mass_update_client_service.cleanup_old_directories()
+
+    assert mock_update_client_service.cleanup.call_count == 2
+    mock_update_client_service.cleanup.assert_any_call("deleted_1")
+    mock_update_client_service.cleanup.assert_any_call("deleted_2")
+
+
+def test_cleanup_old_directories_skips_deleted_directories_when_disabled(
+    mock_update_client_service: MagicMock,
+    mock_directory_provider: MagicMock,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_directory_cache_service: MagicMock
+) -> None:
     mock_directory_info_service.get_all_directories_info.return_value = []
 
+    service = MassUpdateClientService(
+        update_client_service=mock_update_client_service,
+        directory_provider=mock_directory_provider,
+        directory_info_service=mock_directory_info_service,
+        ignored_directory_service=mock_ignored_directory_service,
+        cleanup_client_directory_after_success_timeout_seconds=3600,
+        stats=NoopStats(),
+        directory_cache_service=mock_directory_cache_service,
+        cleanup_client_directory_after_directory_delete=False,
+        ignore_directory_after_success_timeout_seconds=3600,
+        ignore_directory_after_failed_attempts_threshold=5,
+    )
+
     service.cleanup_old_directories()
-    mock_directory_info_service.get_all_directories_info.assert_called()
-    assert mock_update_client_service.cleanup.call_count == 1 # it should not be called again
+
+    mock_directory_cache_service.get_deleted_directories.assert_not_called()
+
+
+def test_cleanup_old_directories_handles_empty_directory_list(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_update_client_service: MagicMock
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = []
+
+    mass_update_client_service.cleanup_old_directories()
+
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_not_called()
+    mock_update_client_service.cleanup.assert_not_called()
+
+
+def test_cleanup_old_directories_mixed_scenarios(
+    mock_update_client_service: MagicMock,
+    mock_directory_provider: MagicMock,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_directory_cache_service: MagicMock,
+    mixed_scenario_directories: list[DirectoryInfo],
+    single_deleted_directory: list[DirectoryDto]
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = mixed_scenario_directories
+    mock_directory_cache_service.get_deleted_directories.return_value = single_deleted_directory
+
+    service = MassUpdateClientService(
+        update_client_service=mock_update_client_service,
+        directory_provider=mock_directory_provider,
+        directory_info_service=mock_directory_info_service,
+        ignored_directory_service=mock_ignored_directory_service,
+        cleanup_client_directory_after_success_timeout_seconds=7200,
+        stats=NoopStats(),
+        directory_cache_service=mock_directory_cache_service,
+        cleanup_client_directory_after_directory_delete=True,
+        ignore_directory_after_success_timeout_seconds=3600,
+        ignore_directory_after_failed_attempts_threshold=5,
+    )
+
+    service.cleanup_old_directories()
+
+    assert mock_ignored_directory_service.add_directory_to_ignore_list.call_count == 3
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_any_call("very_old_directory")
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_any_call("old_directory")
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_any_call("never_synced")
+    
+    assert mock_update_client_service.cleanup.call_count == 2
+    mock_update_client_service.cleanup.assert_any_call("very_old_directory")
+    mock_update_client_service.cleanup.assert_any_call("deleted_directory")
+
+
+def test_cleanup_old_directories_does_not_ignore_already_ignored_failed_directories(
+    mass_update_client_service: MassUpdateClientService,
+    mock_directory_info_service: MagicMock,
+    mock_ignored_directory_service: MagicMock,
+    mock_update_client_service: MagicMock,
+    already_ignored_failed_directory: DirectoryInfo
+) -> None:
+    mock_directory_info_service.get_all_directories_info.return_value = [already_ignored_failed_directory]
+    mock_ignored_directory_service.get_ignored_directory.return_value = MagicMock()
+
+    mass_update_client_service.cleanup_old_directories()
+
+    mock_ignored_directory_service.add_directory_to_ignore_list.assert_not_called()
+    mock_update_client_service.cleanup.assert_not_called()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -74,6 +74,8 @@ def get_test_config() -> Config:
             directory_stale_timeout="120s",
             cleanup_client_directory_after_success_timeout="3d",
             cleanup_client_directory_after_directory_delete=True,
+            ignore_directory_after_success_timeout="120s",
+            ignore_directory_after_failed_attempts_threshold=5,
         ),
         external_cache=ConfigExternalCache(),
     )


### PR DESCRIPTION
Introduce parameters to ignore directories based on success timeout and failed attempts, enhancing the cleanup process by preventing unnecessary deletions of directories that meet certain criteria. Adjust related configurations and methods to accommodate these changes. Add tests for the ignore and cleanup logic.

For coordination PR conf changes see: https://github.com/minvws/gfmodules-coordination-private/pull/582

Closes: #167  