### PR TITLE
Endpoint references can be absolute urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ an app.conf mount.
 Both containers only differ in their init script and the default version usually will mount its own local src directory
 into the container's /src dir.
 
+## URL resolving of resources
+
+When resolving absolute URLs, the application will only resolve resource references according to the same-origin policy. 
+This means that the URL must have the same scheme, host and port as the resource.
+
 ## Contribution
 
 As stated in the [Disclaimer](#disclaimer) this project and all associated code serve solely as documentation and 

--- a/app/services/directory_provider/factory.py
+++ b/app/services/directory_provider/factory.py
@@ -1,5 +1,6 @@
 import json
 from typing import List
+
 from app.models.directory.dto import DirectoryDto
 from app.services.api.authenticators.authenticator import Authenticator
 from app.services.api.fhir_api import FhirApi
@@ -40,7 +41,8 @@ class DirectoryProviderFactory:
                     request_count=5,
                     strict_validation=False
                 ),
-                ignored_directory_service=IgnoredDirectoryService(self.__db)
+                ignored_directory_service=IgnoredDirectoryService(self.__db),
+                provider_url=self.__directory_config.directories_provider_url,
             )
             directory_cache_service = DirectoryCacheService(self.__db)
             return CachingDirectoryProvider(

--- a/app/services/fhir/references/reference_extractor.py
+++ b/app/services/fhir/references/reference_extractor.py
@@ -12,7 +12,12 @@ from fhir.resources.R4B.practitionerrole import PractitionerRole
 
 
 def extract_references(data: Any) -> Reference | None:
+    """
+    Extracts a Reference from the given data if it contains a "reference" field, or when the
+    data is already a Reference object with a valid reference.
+    """
     if isinstance(data, dict):
+        # '#' is a local reference we already have, so we don't need to extract
         if "reference" in data and data["reference"][0] != "#":
             return Reference.model_construct(**data)
 
@@ -32,15 +37,18 @@ def _get_org_references(model: Organization) -> List[Reference]:
             ref = extract_references(endpoint)
             if ref is not None:
                 refs.append(ref)
+
     if part_of is not None:
         new_ref = extract_references(part_of)
         if new_ref is not None:
             refs.append(new_ref)
+
     return refs
 
 
 def _get_endpoint_references(model: Endpoint) -> List[Reference]:
     refs: List[Reference] = []
+
     managing_org = model.managingOrganization
     if managing_org is not None:
         new_ref = extract_references(managing_org)

--- a/app/services/fhir/references/reference_misc.py
+++ b/app/services/fhir/references/reference_misc.py
@@ -1,3 +1,6 @@
+from enum import Enum
+from urllib.parse import urlsplit
+
 from fhir.resources.R4B.reference import Reference
 
 
@@ -16,3 +19,56 @@ def split_reference(data: Reference) -> tuple[str, str]:
         )
 
     return parts[-2], parts[-1]
+
+
+class ReferenceType(Enum):
+    RELATIVE = "relative"
+    ABSOLUTE = "absolute"
+    LOCAL = "local"
+    LOGICAL = "logical"
+    CANONICAL = "canonical"
+    UNKNOWN = "unknown"
+
+def get_reference_type(data: Reference) -> ReferenceType:
+    ref = data.reference
+    identifier = data.identifier
+
+    # logical reference (identifier only, no `reference`)
+    if identifier is not None and not ref:
+        return ReferenceType.LOGICAL
+
+    if ref:
+        if ref.startswith("#"):
+            return ReferenceType.LOCAL
+        if ref.startswith("http://") or ref.startswith("https://"):
+            # canonical references are also absolute, but have a specific pattern
+            if "|" in ref:  # versioned canonical
+                return ReferenceType.CANONICAL
+            return ReferenceType.ABSOLUTE
+        if "/" in ref:
+            return ReferenceType.RELATIVE
+
+    return ReferenceType.UNKNOWN
+
+
+def is_same_origin(url1: str, url2: str) -> bool:
+    """
+    Returns true if the URLs have the same origin.
+    See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy
+    """
+
+    def origin_tuple(url: str) -> tuple[str, str, int]|None:
+        parts = urlsplit(url)
+        if not (parts.scheme and parts.netloc):
+            return None
+
+        scheme = parts.scheme.lower()
+        host = (parts.hostname or "").lower()
+        port = parts.port
+        if port is None:
+            port = 80 if scheme == "http" else 443
+
+        return (scheme, host, port)
+
+    print("Checking origin for URLs:", url1, url2)
+    return origin_tuple(url1) == origin_tuple(url2)

--- a/app/services/fhir/references/reference_namespacer.py
+++ b/app/services/fhir/references/reference_namespacer.py
@@ -26,7 +26,7 @@ def _namespace_reference(data: Any, namespace: str) -> Reference | None:
     return ref
 
 
-def _namesapce_organization_references(
+def _namespace_organization_references(
     data: Organization, namespace: str
 ) -> Organization:
     endpoints = data.endpoint
@@ -244,7 +244,7 @@ def namespace_resource_reference(
 ) -> DomainResource:
     new_data = data
     if isinstance(data, Organization):
-        new_data = _namesapce_organization_references(data, namespace)
+        new_data = _namespace_organization_references(data, namespace)
 
     if isinstance(data, Endpoint):
         new_data = _namespace_endpoint_references(data, namespace)

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -171,7 +171,7 @@ organization_affiliation: Final[Dict[str, Any]] = {
     "identifier": [{"system": "example", "value": "example"}],
     "active": True,
     "organization": {"reference": "Organization/org-id"},
-    "participatingOrganization": {"reference": "Organization/org-id-2"},
+    "participatingOrganization": {"reference": "https://foobar.com/Organization/org-id-2"},
     "code": [{"coding": [{"system": "example", "code": "example"}]}],
     "location": [{"reference": "Location/loc-id"}],
     "network": [

--- a/tests/services/fhir/test_fhir_service.py
+++ b/tests/services/fhir/test_fhir_service.py
@@ -24,7 +24,7 @@ from tests.services.fhir.conftest import (
 
 
 @pytest.mark.parametrize("data", incomplete_resources)
-def test_create_resource_should_succeeed_when_strict_mode_is_off(
+def test_create_resource_should_succeed_when_strict_mode_is_off(
     fhir_service: FhirService, data: Dict[str, Any]
 ) -> None:
     actual = fhir_service.create_resource(data)

--- a/tests/services/fhir/test_reference_types.py
+++ b/tests/services/fhir/test_reference_types.py
@@ -1,0 +1,90 @@
+import pytest
+from fhir.resources.R4B.reference import Reference
+
+from app.services.fhir.references.reference_misc import ReferenceType, get_reference_type, is_same_origin
+
+
+@pytest.mark.parametrize("ref_str,expected", [
+    ("Patient/123", ReferenceType.RELATIVE),
+    ("Observation/abc-123/_history/2", ReferenceType.RELATIVE),
+    ("https://fhir.example.org/Patient/123", ReferenceType.ABSOLUTE),
+    ("http://example.com/fhir/Patient/42", ReferenceType.ABSOLUTE),
+    ("#pr1", ReferenceType.LOCAL),
+    ("http://hl7.org/fhir/StructureDefinition/bp|4.0.1", ReferenceType.CANONICAL),
+])
+def test_reference_reference_field_variants(ref_str: str, expected: ReferenceType) -> None:
+    ref = Reference(reference=ref_str)
+    assert get_reference_type(ref) == expected
+
+
+def test_reference_logical_identifier_only() -> None:
+    ref = Reference(
+        identifier={
+            "system": "http://hospital.example.org/mrn",
+            "value": "123456"
+        }
+    )
+    assert get_reference_type(ref) == ReferenceType.LOGICAL
+
+
+def test_reference_both_identifier_and_reference_prefers_reference() -> None:
+    ref = Reference(
+        reference="Patient/123",
+        identifier={"system": "http://hospital.example.org/mrn", "value": "123456"}
+    )
+    assert get_reference_type(ref) == ReferenceType.RELATIVE
+
+
+def test_reference_unknown_when_empty() -> None:
+    ref = Reference()
+    assert get_reference_type(ref) == ReferenceType.UNKNOWN
+
+
+@pytest.mark.parametrize("ref_str,expected", [
+    ("http://hl7.org/fhir/StructureDefinition/bp", ReferenceType.ABSOLUTE),
+    ("https://example.org/Patient/1?ver=1|2", ReferenceType.CANONICAL),
+])
+def test_reference_edge_cases(ref_str: str, expected: ReferenceType) -> None:
+    ref = Reference(reference=ref_str)
+    assert get_reference_type(ref) == expected
+
+
+@pytest.mark.parametrize("url1,url2,expected", [
+    ("https://fhir.example.org/baseR4",
+     "https://fhir.example.org/Patient/123",
+     True),
+
+    ("https://fhir.example.org/baseR4",
+     "https://foobar.example.org/Patient/123",
+     False),
+
+    ("https://fhir.example.org/baseR4",
+     "https://foobar.example.org/baseR4",
+     False),
+
+    ("https://fhir.example.org",
+     "http://fhir.example.org",
+     False),
+
+    ("https://fhir.example.org",
+     "https://other.example.org",
+     False),
+
+    ("https://fhir.example.org",
+     "https://fhir.example.org:443/Patient/123",
+     True),
+
+    ("http://fhir.example.org",
+     "http://fhir.example.org:80/Patient/123",
+     True),
+
+    ("http://fhir.example.org:8080",
+     "http://fhir.example.org:80",
+     False),
+
+    ("HTTPS://FHIR.EXAMPLE.ORG",
+     "https://fhir.example.org",
+     True),
+])
+def test_is_same_origin(url1: str, url2: str, expected: bool) -> None:
+    assert is_same_origin(url1, url2) == expected


### PR DESCRIPTION
Note that these absolute urls MUST be of the same-origin in order, otherwise the organization is not added to the result list.