### PR TITLE
refactor: reference extractor model

### DIFF
--- a/app/models/fhir/types.py
+++ b/app/models/fhir/types.py
@@ -1,5 +1,5 @@
 from typing import Literal
-
+from enum import Enum
 from pydantic import BaseModel
 
 HttpValidVerbs = Literal["GET", "POST", "PATCH", "POST", "PUT", "HEAD", "DELETE"]
@@ -8,3 +8,13 @@ HttpValidVerbs = Literal["GET", "POST", "PATCH", "POST", "PUT", "HEAD", "DELETE"
 class BundleRequestParams(BaseModel):
     id: str
     resource_type: str
+
+
+class McsdResources(Enum):
+    ORGANIZATION_AFFILIATION = "OrganizationAffiliation"
+    PRACTITIONER_ROLE = "PractitionerRole"
+    HEALTH_CARE_SERVICE = "HealthcareService"
+    LOCATION = "Location"
+    PRACTITIONER = "Practitioner"
+    ORGANIZATION = "Organization"
+    ENDPOINT = "Endpoint"

--- a/app/services/directory_provider/api_provider.py
+++ b/app/services/directory_provider/api_provider.py
@@ -32,7 +32,9 @@ class DirectoryApiProvider(DirectoryProvider):
             include_ignored=include_ignored, include_ignored_ids=None
         )
 
-    def get_all_directories_include_ignored(self, include_ignored_ids: List[str]) -> List[DirectoryDto]:
+    def get_all_directories_include_ignored(
+        self, include_ignored_ids: List[str]
+    ) -> List[DirectoryDto]:
         return self.__fetch_directories(
             include_ignored=False, include_ignored_ids=include_ignored_ids
         )
@@ -46,7 +48,6 @@ class DirectoryApiProvider(DirectoryProvider):
             ignored_directories = (
                 self.__ignored_directory_service.get_all_ignored_directories()
             )
-
 
         # Keep on fetching until next_url is None (ie: no more pages)
         params = {
@@ -92,7 +93,7 @@ class DirectoryApiProvider(DirectoryProvider):
                 params=params,
             )
 
-            orgs, endpoint_map = self.__parse_bundle(entries)   # type: ignore[arg-type]
+            orgs, endpoint_map = self.__parse_bundle(entries)  # type: ignore[arg-type]
 
             org = next(iter(orgs), None)
             if not org:
@@ -128,16 +129,18 @@ class DirectoryApiProvider(DirectoryProvider):
             logger.warning(f"Check for deleted directory {directory_id} failed: {e}")
             return False
 
-    def __parse_bundle(self, entries: BundleEntry) -> tuple[List[Organization], Dict[str, Endpoint]]:
+    def __parse_bundle(
+        self, entries: BundleEntry
+    ) -> tuple[List[Organization], Dict[str, Endpoint]]:
         orgs: List[Organization] = []
         endpoint_map: Dict[str, Any] = {}
 
         for entry in entries:
-            resource = entry.resource       # type: ignore[attr-defined]
+            resource = entry.resource  # type: ignore[attr-defined]
             if isinstance(resource, Organization):
                 orgs.append(resource)
             elif isinstance(resource, Endpoint):
-                endpoint_map[resource.id] = resource    # type: ignore[index]
+                endpoint_map[resource.id] = resource  # type: ignore[index]
 
         return orgs, endpoint_map
 
@@ -164,7 +167,9 @@ class DirectoryApiProvider(DirectoryProvider):
             is_deleted=False,
         )
 
-    def __get_endpoint_address(self, org: Organization, endpoint_map: Dict[str, Endpoint]) -> str | None:
+    def __get_endpoint_address(
+        self, org: Organization, endpoint_map: Dict[str, Endpoint]
+    ) -> str | None:
         if org.endpoint is None:
             return None
         ref = self.__fhir_service.get_references(org) if org.endpoint else None

--- a/app/services/fhir/fhir_service.py
+++ b/app/services/fhir/fhir_service.py
@@ -15,7 +15,6 @@ from app.services.fhir.bundle.bundle_parser import (
 )
 from app.services.fhir.model_factory import create_resource
 from app.services.fhir.references.reference_extractor import (
-    extract_references,
     get_references,
 )
 from app.services.fhir.references.reference_misc import split_reference
@@ -36,12 +35,6 @@ class FhirService:
         Creates a defined FHIR mCSD resource model.
         """
         return create_resource(data, self.strict_validation)
-
-    def extract_references(self, data: Any) -> Reference | None:
-        """
-        Builds a Reference object only if the "reference" exists in the object
-        """
-        return extract_references(data)
 
     def get_references(self, data: DomainResource) -> List[Reference]:
         """

--- a/app/services/fhir/references/reference_extractor.py
+++ b/app/services/fhir/references/reference_extractor.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, List
+from fhir.resources.R4B.backboneelement import BackboneElement
 from fhir.resources.R4B.domainresource import DomainResource
 from fhir.resources.R4B.healthcareservice import HealthcareService
 from fhir.resources.R4B.reference import Reference
@@ -7,226 +8,92 @@ from fhir.resources.R4B.organization import Organization
 from fhir.resources.R4B.organizationaffiliation import OrganizationAffiliation
 from fhir.resources.R4B.endpoint import Endpoint
 from fhir.resources.R4B.location import Location
-from fhir.resources.R4B.practitioner import Practitioner, PractitionerQualification
+from fhir.resources.R4B.practitioner import Practitioner
 from fhir.resources.R4B.practitionerrole import PractitionerRole
 
 
+def _is_ref(data: Any) -> bool:
+    """
+    Helper function to validate if data is a valid Reference by checking against
+    the class and Dict
+    """
+    if isinstance(data, Reference):
+        return True
+
+    if isinstance(data, dict) and "reference" in data.keys():
+        return True
+
+    return False
+
+
+def _is_backbone_element(data: Any) -> bool:
+    return isinstance(data, BackboneElement)
+
+
+def _from_backbone_element(data: BackboneElement) -> List[Reference]:
+    fields = [getattr(data, name) for name in data.elements_sequence()]  # type: ignore
+    fields = [field for field in fields if fields]
+
+    refs = [extract_references(ref) for ref in fields if _is_ref(ref)]
+    return [ref for ref in refs if ref]
+
+
+def extract_model_references(model: DomainResource) -> List[Reference]:
+    """
+    Extracts references from an mCSD resource by going through the properties
+    of the model.
+    """
+    # extract fields of the model and filter the None values
+    fields = [getattr(model, field) for field in model.elements_sequence()]  # type: ignore
+    fields = [field for field in fields if field]
+
+    # get the refs on the root level and filter None
+    root_refs = [extract_references(ref) for ref in fields if _is_ref(ref)]
+    filtered_root_refs = [ref for ref in root_refs if ref]
+
+    # extract sublists of the model and flatten it
+    sub_lists = [sublist for sublist in fields if isinstance(sublist, list)]
+    flattened_list = [element for sublist in sub_lists for element in sublist]
+
+    # get the refs from the flattened sublists and filter nones
+    sublist_refs = [
+        extract_references(data) for data in flattened_list if _is_ref(data)
+    ]
+    filtered_sublist_refs = [ref for ref in sublist_refs if ref]
+
+    # extract BackboneElements from the flattened sublists
+    backbone_elements = [
+        element for element in flattened_list if _is_backbone_element(element)
+    ]
+    nested_backbone_elements_refs = [
+        _from_backbone_element(data) for data in backbone_elements
+    ]
+    # get the refs of those sublists
+    flattened_backbone_elements_refs = [
+        ref for sublist in nested_backbone_elements_refs for ref in sublist
+    ]
+
+    return [
+        *filtered_root_refs,
+        *filtered_sublist_refs,
+        *flattened_backbone_elements_refs,
+    ]
+
+
 def extract_references(data: Any) -> Reference | None:
+    """
+    Helper function that extracts refs from a data by checking if the item is a Dict
+    or an instance of the Reference. This function also ignores contained references.
+    """
     if isinstance(data, dict):
         if "reference" in data and data["reference"][0] != "#":
-            return Reference.model_construct(**data)
+            return Reference(**data)
 
     if isinstance(data, Reference):
         if data.reference is not None and not data.reference.startswith("#"):
             return data
 
     return None
-
-
-def _get_org_references(model: Organization) -> List[Reference]:
-    """
-    Extracts "endpoint" and "part-of" references from an Organization resource.
-    """
-    refs: List[Reference] = []
-    endpoints = model.endpoint
-    part_of = model.partOf
-    if endpoints is not None:
-        for endpoint in endpoints:
-            ref = extract_references(endpoint)
-            if ref is not None:
-                refs.append(ref)
-    if part_of is not None:
-        new_ref = extract_references(part_of)
-        if new_ref is not None:
-            refs.append(new_ref)
-    return refs
-
-
-def _get_endpoint_references(model: Endpoint) -> List[Reference]:
-    """
-    Extracts "managing-organization" references from an Endpoint resource.
-    """
-    refs: List[Reference] = []
-    managing_org = model.managingOrganization
-    if managing_org is not None:
-        new_ref = extract_references(managing_org)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    return refs
-
-
-def _get_org_affiliation_references(model: OrganizationAffiliation) -> List[Reference]:
-    """
-    Extracts references from an OrganizationAffiliation resource, including organization,
-    """
-    refs: List[Reference] = []
-    organization = model.organization
-    participating_org = model.participatingOrganization
-    network = model.network
-    location = model.location
-    healthcare_service = model.healthcareService
-    endpoints = model.endpoint
-
-    if organization is not None:
-        new_ref = extract_references(organization)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if participating_org is not None:
-        new_ref = extract_references(participating_org)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if network is not None:
-        for org in network:
-            new_ref = extract_references(org)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if location is not None:
-        for loc in location:
-            new_ref = extract_references(loc)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if healthcare_service is not None:
-        for service in healthcare_service:
-            new_ref = extract_references(service)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if endpoints is not None:
-        for endpoint in endpoints:
-            new_ref = extract_references(endpoint)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    return refs
-
-
-def _get_location_references(model: Location) -> List[Reference]:
-    """
-    Extracts references from a Location resource, including managing-organization,
-    """
-    refs: List[Reference] = []
-    managing_org = model.managingOrganization
-    part_of = model.partOf
-    endpoints = model.endpoint
-
-    if managing_org is not None:
-        new_ref = extract_references(managing_org)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if part_of is not None:
-        new_ref = extract_references(part_of)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if endpoints is not None:
-        for endpoint in endpoints:
-            new_ref = extract_references(endpoint)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    return refs
-
-
-def _get_practitioner_references(model: Practitioner) -> List[Reference]:
-    """
-    Extracts references from a Practitioner resource, including qualification issuer.
-    """
-    refs: List[Reference] = []
-    qualifications = model.qualification
-    if qualifications is not None:
-        for qualification in qualifications:
-            if isinstance(qualification, PractitionerQualification):
-                issuer = qualification.issuer       # type: ignore[attr-defined]
-
-                new_ref = extract_references(issuer)
-                if new_ref is not None:
-                    refs.append(new_ref)
-
-    return refs
-
-
-def _get_practitioner_role_references(model: PractitionerRole) -> List[Reference]:
-    """
-    Extracts references from a PractitionerRole resource, including practitioner,
-    """
-    refs: List[Reference] = []
-    practitioner = model.practitioner
-    organization = model.organization
-    locations = model.location
-    healthcare_services = model.healthcareService
-    endpoints = model.endpoint
-
-    if practitioner is not None:
-        new_ref = extract_references(practitioner)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if organization is not None:
-        new_ref = extract_references(organization)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    if locations is not None:
-        for location in locations:
-            new_ref = extract_references(location)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if healthcare_services is not None:
-        for healthcare_service in healthcare_services:
-            new_ref = extract_references(healthcare_service)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if endpoints is not None:
-        for endpoint in endpoints:
-            new_ref = extract_references(endpoint)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    return refs
-
-
-def _get_healthcare_service_references(model: HealthcareService) -> List[Reference]:
-    """
-    Extracts references from a HealthcareService resource, including location,
-    """
-    refs: List[Reference] = []
-    locations = model.location
-    coverage_areas = model.coverageArea
-    endpoints = model.endpoint
-    provided_by = model.providedBy
-
-    if locations is not None:
-        for loc in locations:
-            new_ref = extract_references(loc)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if coverage_areas is not None:
-        for cov in coverage_areas:
-            new_ref = extract_references(cov)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if endpoints is not None:
-        for endpoint in endpoints:
-            new_ref = extract_references(endpoint)
-            if new_ref is not None:
-                refs.append(new_ref)
-
-    if provided_by is not None:
-        new_ref = extract_references(provided_by)
-        if new_ref is not None:
-            refs.append(new_ref)
-
-    return refs
 
 
 def _make_unique(data: List[Reference]) -> List[Reference]:
@@ -245,24 +112,24 @@ def get_references(data: DomainResource) -> List[Reference]:
     """
     refs: List[Reference] = []
     if isinstance(data, Organization):
-        refs.extend(_get_org_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, Endpoint):
-        refs.extend(_get_endpoint_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, OrganizationAffiliation):
-        refs.extend(_get_org_affiliation_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, Location):
-        refs.extend(_get_location_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, Practitioner):
-        refs.extend(_get_practitioner_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, PractitionerRole):
-        refs.extend(_get_practitioner_role_references(data))
+        refs.extend(extract_model_references(data))
 
     if isinstance(data, HealthcareService):
-        refs.extend(_get_healthcare_service_references(data))
+        refs.extend(extract_model_references(data))
 
     return _make_unique(refs)

--- a/app/services/fhir/references/reference_namespacer.py
+++ b/app/services/fhir/references/reference_namespacer.py
@@ -11,14 +11,14 @@ from fhir.resources.R4B.practitioner import Practitioner, PractitionerQualificat
 from fhir.resources.R4B.practitionerrole import PractitionerRole
 
 from app.services.fhir.bundle.bundle_utils import get_resource_from_reference
-from app.services.fhir.references.reference_extractor import extract_references
+from app.services.fhir.references.reference_extractor import extract_reference
 
 
 def _namespace_reference(data: Any, namespace: str) -> Reference | None:
     """
     Finds a single reference in the data and converts it to namespaced references.
     """
-    ref = extract_references(data)
+    ref = extract_reference(data)
     if ref is None or ref.reference is None:
         return None
     res_type, _id = get_resource_from_reference(ref.reference)

--- a/app/services/update/update_client_service.py
+++ b/app/services/update/update_client_service.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 import time
-from enum import Enum
 import logging
 from typing import Dict, List, Any
 from uuid import uuid4
+from app.models.fhir.types import McsdResources
 from app.services.update.cache.provider import CacheProvider
 from app.services.update.cache.caching_service import (
     CachingService,
@@ -29,16 +29,6 @@ from app.services.fhir.fhir_service import FhirService
 from app.services.api.fhir_api import FhirApi
 
 logger = logging.getLogger(__name__)
-
-
-class McsdResources(Enum):
-    ORGANIZATION_AFFILIATION = "OrganizationAffiliation"
-    PRACTITIONER_ROLE = "PractitionerRole"
-    HEALTH_CARE_SERVICE = "HealthcareService"
-    LOCATION = "Location"
-    PRACTITIONER = "Practitioner"
-    ORGANIZATION = "Organization"
-    ENDPOINT = "Endpoint"
 
 
 class UpdateClientService:
@@ -124,7 +114,9 @@ class UpdateClientService:
                         directory_resource_id=res_map_item.directory_resource_id,
                     )
                 )
-            if delete_bundle.total is not None and delete_bundle.total > 0:  # Final flush of remaining items
+            if (
+                delete_bundle.total is not None and delete_bundle.total > 0
+            ):  # Final flush of remaining items
                 logging.info(
                     f"Removing {delete_bundle.total} items from update client originating from stale directory {directory_id}"
                 )

--- a/tests/services/fhir/test_fhir_service.py
+++ b/tests/services/fhir/test_fhir_service.py
@@ -8,6 +8,7 @@ from fhir.resources.R4B.organization import Organization
 from fhir.resources.R4B.organizationaffiliation import OrganizationAffiliation
 from fhir.resources.R4B.practitioner import Practitioner
 from fhir.resources.R4B.practitionerrole import PractitionerRole
+from fhir.resources.R4B.medication import Medication
 from fhir.resources.R4B.reference import Reference
 from pydantic import ValidationError
 import pytest
@@ -133,6 +134,16 @@ def test_get_references_should_ignore_contained_refs(
     actual_refs = fhir_service.get_references(resource)
 
     assert expected_refs == actual_refs
+
+
+def test_get_references_should_raise_exception_with_non_mcsd_resource(
+    fhir_service: FhirService,
+) -> None:
+    non_mcsd_resource = Medication(
+        id="some-id", manufacturer=Reference(reference="Organization/some-org-id")
+    )
+    with pytest.raises(ValueError):
+        fhir_service.get_references(non_mcsd_resource)
 
 
 @pytest.mark.parametrize(
@@ -323,8 +334,8 @@ def test_create_bundle_request_should_succeed(fhir_service: FhirService) -> None
     assert len(results.entry) == 1
     assert isinstance(results.entry, List)
     assert isinstance(results.entry[0], BundleEntry)
-    assert isinstance(results.entry[0].request, BundleEntryRequest) # type: ignore[attr-defined]
-    assert results.entry[0].request.method == "GET" # type: ignore[attr-defined]
+    assert isinstance(results.entry[0].request, BundleEntryRequest)  # type: ignore[attr-defined]
+    assert results.entry[0].request.method == "GET"  # type: ignore[attr-defined]
 
 
 def test_get_entries_from_bundle_of_bundles_should_succeed(

--- a/tests/services/update/test_update_client_service.py
+++ b/tests/services/update/test_update_client_service.py
@@ -1,10 +1,10 @@
 from typing import Sequence
 from unittest.mock import ANY, MagicMock
 from app.config import ConfigExternalCache
+from app.models.fhir.types import McsdResources
 from app.services.update.cache.provider import CacheProvider
 from app.services.update.update_client_service import (
     UpdateClientService,
-    McsdResources,
 )
 from fhir.resources.R4B.bundle import Bundle, BundleEntry, BundleEntryRequest
 
@@ -76,10 +76,10 @@ def test_cleanup() -> None:
         assert called_bundle.entry is not None
         assert len(called_bundle.entry) == 2
         assert isinstance(called_bundle.entry[0], BundleEntry)
-        assert isinstance(called_bundle.entry[0].request, BundleEntryRequest) # type: ignore[attr-defined]
-        assert called_bundle.entry[0].request.method == "DELETE" # type: ignore[attr-defined]
-        assert called_bundle.entry[0].request.url is not None # type: ignore[attr-defined]
-        split = called_bundle.entry[0].request.url.split("/") # type: ignore[attr-defined]
+        assert isinstance(called_bundle.entry[0].request, BundleEntryRequest)  # type: ignore[attr-defined]
+        assert called_bundle.entry[0].request.method == "DELETE"  # type: ignore[attr-defined]
+        assert called_bundle.entry[0].request.url is not None  # type: ignore[attr-defined]
+        split = called_bundle.entry[0].request.url.split("/")  # type: ignore[attr-defined]
         assert split[0] == resource.value
         assert (
             split[1] == "resource_1?_cascade=delete"

--- a/tests/utils/mcsd_resource_gen.py
+++ b/tests/utils/mcsd_resource_gen.py
@@ -2,7 +2,7 @@ from random import choice
 from typing import Any, Dict
 from uuid import uuid4
 
-from app.services.update.update_client_service import McsdResources
+from app.models.fhir.types import McsdResources
 from seeds.generate_data import DataGenerator
 import os
 import json
@@ -169,7 +169,7 @@ def setup_fhir_resource(
             ).model_dump_json()
     save_resource_version(
         resource_id_folder=f"{base_path}/{mcsd_res_type.value}/{resource_id}",
-        resource=resource,      # type: ignore[arg-type]
+        resource=resource,  # type: ignore[arg-type]
         version=version,
     )
     return resource_id
@@ -223,10 +223,12 @@ def generate_post_bundle(base_path: str) -> None:
                         },
                     }
                     resource_2 = copy.deepcopy(resource)
-                    resource_2["identifier"] = [{
-                        "system": f"http://example.com/{str(uuid4())}",
-                        "value": str(uuid4())
-                    }]
+                    resource_2["identifier"] = [
+                        {
+                            "system": f"http://example.com/{str(uuid4())}",
+                            "value": str(uuid4()),
+                        }
+                    ]
                     entry_2 = {
                         "fullUrl": f"{resource_type.value}/{resource_id}",
                         "resource": resource_2,

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -11,11 +11,11 @@ from app.models.adjacency.node import (
     NodeReference,
     NodeUpdateData,
 )
+from app.models.fhir.types import McsdResources
 from app.services.fhir.fhir_service import FhirService
 import numpy as np
 from app.container import get_database
 from app.db.repositories.resource_map_repository import ResourceMapRepository
-from app.services.update.update_client_service import McsdResources
 from .mcsd_resource_gen import (
     generate_history_bundles,
     generate_post_bundle,


### PR DESCRIPTION
- refactor: reference extractor by reducing boiler plate code and generalising the extraction approach.
- refactor: move common data types definition to their appropriate place.
- tests: added tests to newly refactored code.

related to https://github.com/minvws/gfmodules-mcsd-update-client/issues/173