### PR TITLE
Build venv package for Python 3.11.2

### DIFF
--- a/.github/workflows/release-package-venv.yaml
+++ b/.github/workflows/release-package-venv.yaml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python_version: ['3.11']
+        python_version: ['3.11.2']
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
As we are using Redis and running the application with Python 3.11.2.

Related: https://github.com/redis/redis-py/blob/ea22b12c64e99c0379562a5e1da94b0882507dd3/pyproject.toml#L31