### PR TITLE
feat: add capability statement validation for mCSD compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,18 @@ docker compose run --rm mcsd-update-client poetry run seed http://hapi-directory
 
 There are two ways to build a docker container from this application. The first is the default mode created with:
 
-    make container-build
+```bash
+make container-build
+```
 
 This will build a docker container that will run its migrations to the database specified in app.conf.
 
 The second mode is a "standalone" mode, where it will not generate migrations, and where you must explicitly specify
 an app.conf mount.
 
-    make container-build-sa
+```bash
+make container-build-sa
+```
 
 Both containers only differ in their init script and the default version usually will mount its own local src directory
 into the container's /src dir.
@@ -97,12 +101,30 @@ into the container's /src dir.
 When encountering absolute URLS in references, they will be resolved ONLY when the URL is of the same origin. Otherwise
 it will throw an exception.
 
+## Required interactions for FHIR directories
+
+The Update Client can check if a FHIR directory supports the required interactions by checking its CapabilityStatement.
+This is done automatically if enabled in the config file. There are a few requirements for the CapabilityStatement
+to be valid. A general mCSD capability statement can be found <https://profiles.ihe.net/ITI/mCSD/CapabilityStatement-IHE.mCSD.Directory.html>. This Update-client requires FHIR servers to support the following resources with the specified interactions according to the FHIR R4 specs:
+
+| Resource       | Interactions required               |
+|----------------|------------------------------------|
+| Organization   | read, search-type, history-type |
+| Practitioner   | read, search-type, history-type   |
+| PractitionerRole | read, search-type, history-type |
+| Location       | read, search-type, history-type   |
+| Endpoint       | read, search-type, history-type   |
+| HealthcareService | read, search-type, history-type |
+| OrganizationAffiliation | read, search-type, history-type |
+
+Further it must be an FHIR R4 Rest server and work without authentication.
+
 ## Contribution
 
-As stated in the [Disclaimer](#disclaimer) this project and all associated code serve solely as documentation and 
+As stated in the [Disclaimer](#disclaimer) this project and all associated code serve solely as documentation and
 demonstration purposes to illustrate potential system communication patterns and architectures.
 
-For that reason we will only accept contributions that fit this goal. We do appreciate any effort from the 
+For that reason we will only accept contributions that fit this goal. We do appreciate any effort from the
 community, but because our time is limited it is possible that your PR or issue is closed without a full justification.
 
 If you plan to make non-trivial changes, we recommend to open an issue beforehand where we can discuss your planned changes. This increases the chance that we might be able to use your contribution (or it avoids doing work if there are reasons why we wouldn't be able to use it).

--- a/app/config.py
+++ b/app/config.py
@@ -266,6 +266,7 @@ class ConfigMcsd(BaseModel):
     mtls_client_cert_path: str | None = Field(default=None)
     mtls_client_key_path: str | None = Field(default=None)
     mtls_server_ca_path: str | None = Field(default=None)
+    check_capability_statement: bool = Field(default=False, description="Whether to check the CapabilityStatement of client directories")
 
     @field_validator("request_count", mode="before")
     def validate_request_count(cls, v: Any) -> int:

--- a/app/services/directory_provider/factory.py
+++ b/app/services/directory_provider/factory.py
@@ -36,6 +36,7 @@ class DirectoryProviderFactory:
                     self.__directory_config.directory_urls_path
                 ),
                 ignored_directory_service=IgnoredDirectoryService(self.__db),
+                validate_capability_statement=self.__mcsd_config.check_capability_statement,
             )
         elif self.__directory_config.directories_provider_url is not None:
             # Use API-based provider if directories_provider_url is provided
@@ -59,6 +60,7 @@ class DirectoryProviderFactory:
             return CachingDirectoryProvider(
                 directory_provider=directory_api_provider,
                 directory_cache_service=directory_cache_service,
+                validate_capability_statement=self.__mcsd_config.check_capability_statement,
             )
         else:
             raise ValueError(

--- a/app/services/directory_provider/json_provider.py
+++ b/app/services/directory_provider/json_provider.py
@@ -12,26 +12,32 @@ class DirectoryJsonProvider(DirectoryProvider):
     """
     directory_urls: List[DirectoryDto]
 
-    def __init__(self, directories_json_data: List[DirectoryDto], ignored_directory_service: IgnoredDirectoryService) -> None:
+    def __init__(self, directories_json_data: List[DirectoryDto], ignored_directory_service: IgnoredDirectoryService, validate_capability_statement: bool = False) -> None:
         self.__directories = directories_json_data
         self.__ignored_directory_service = ignored_directory_service
+        self.__validate_capability_statement = validate_capability_statement
 
     def get_all_directories(self, include_ignored: bool = False) -> List[DirectoryDto]:
         if not include_ignored:
             self.__ignored_directory_service.get_all_ignored_directories()
-            return [
+            directories = [
                 directory for directory in self.__directories
                 if not any(dir.directory_id == directory.id for dir in self.__ignored_directory_service.get_all_ignored_directories())
             ]
-
+            if self.__validate_capability_statement:
+                directories = [d for d in directories if self.check_capability_statement(d)]
+            return directories
         return self.__directories
 
     def get_all_directories_include_ignored(self, include_ignored_ids: List[str]) -> List[DirectoryDto]:
         ignored_directories = self.__ignored_directory_service.get_all_ignored_directories()
-        return [
+        directories = [
             directory for directory in self.__directories
             if directory.id in include_ignored_ids or not any(dir.directory_id == directory.id for dir in ignored_directories)
         ]
+        if self.__validate_capability_statement:
+            directories = [d for d in directories if self.check_capability_statement(d)]
+        return directories
 
     def get_one_directory(self, directory_id: str) -> DirectoryDto:
         directory = next((s for s in self.__directories if s.id == directory_id), None)
@@ -39,5 +45,10 @@ class DirectoryJsonProvider(DirectoryProvider):
             raise HTTPException(
                 status_code=404,
                 detail=f"Directory with ID '{directory_id}' not found."
+            )
+        if self.__validate_capability_statement and not self.check_capability_statement(directory):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Directory {directory.id} at {directory.endpoint} does not support mCSD requirements",
             )
         return directory

--- a/app/services/fhir/capability_statement_validator.py
+++ b/app/services/fhir/capability_statement_validator.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict
+from fhir.resources.R4B.capabilitystatement import CapabilityStatement, CapabilityStatementRest
+
+from app.models.fhir.types import McsdResources
+
+
+# Constants
+REQUIRED_INTERACTIONS = {"read", "search-type", "history-type"}
+def is_capability_statement_valid(data: Dict[str, Any]) -> bool:
+    """
+    Check if CapabilityStatement supports mCSD requirements.
+    
+    Args:
+        data: Dictionary FHIR CapabilityStatement
+        
+    Returns:
+        True if supports required operations, False otherwise
+    """
+    try:
+        capability_statement = CapabilityStatement.model_validate(data)
+    except Exception:
+        return False
+
+    server_rest = _find_server_rest(capability_statement)
+    if not server_rest:
+        return False
+
+    return _validate_mcsd_resources(server_rest)
+
+
+def _find_server_rest(capability_statement: CapabilityStatement) -> CapabilityStatementRest | None:
+    """Find the server mode REST configuration."""
+    if not capability_statement.rest:
+        return None
+        
+    for rest in capability_statement.rest:
+        if rest and getattr(rest, 'mode', None) == "server":
+            return rest
+    return None
+
+
+def _validate_mcsd_resources(server_rest: CapabilityStatementRest) -> bool:
+    """Check if all required mCSD resources are supported with correct interactions."""
+    if not getattr(server_rest, 'resource', None):
+        return False
+
+    supported_resources = _create_supported_resources_map(server_rest)
+
+    # Check that all required mCSD resources are present
+    for required_resource in {resource.value for resource in McsdResources}:
+        if required_resource not in supported_resources:
+            return False
+        
+        # Check if all required interactions are supported
+        resource_interactions = supported_resources[required_resource]
+        if not REQUIRED_INTERACTIONS.issubset(resource_interactions):
+            return False
+
+    return True
+
+
+def _create_supported_resources_map(server_rest: CapabilityStatementRest) -> Dict[str, set[Any | None]]:
+    """Create a map of supported resources with their interactions."""
+    supported_resources = {}
+    for resource in server_rest.resource: # type: ignore
+        if resource and hasattr(resource, 'type'):
+            resource_type = resource.type
+            interactions = set()
+            if hasattr(resource, 'interaction') and resource.interaction:
+                interactions = {
+                    getattr(interaction, 'code', None) 
+                    for interaction in resource.interaction 
+                    if interaction and hasattr(interaction, 'code')
+                }
+            supported_resources[resource_type] = interactions
+    return supported_resources

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,8 +25,8 @@ graph TD
     
 ```
 
-
 ## Update service
+
 The Update service is responsible for polling from one or more FHIR directories for new or updated resources. It does so by comparing data against the addressing FHIR Directory and make decisions based on the outcome of the comparison. When an update is found, it modifies any internal id and references by namespacing them according to the id of the server it is polling data from. This is essential to avoid id collisions and so that references point to the addressing FHIR server before updating the resource on that server.
 
 For instance, take the following Organization resource found in a directory:
@@ -53,10 +53,9 @@ In this case, the "id" is the original logical [id](https://build.fhir.org/resou
     "reference": "http://addressing-fhir-server/Organization/directory-id-2"
   }
 }
+```
 
 This allows for a consistent and unified view of resources across multiple directories, ensuring that all references are correctly resolved to the addressing FHIR server. And avoid any id conflicts between different directories the app is trying to pull data from.
-
-
 
 ### Polling for update
 
@@ -64,19 +63,17 @@ The update service a polling mechanism to periodically check one or more FHIR di
 
 It will take care of only fetching resources that have been created or updated since the last successful poll, using the `_lastUpdated` search parameter. This ensures that the update process is efficient and only processes new or changed data.
 
+As part of the start of the polling process, the client will also validate that the FHIR directory supports the required mCSD resources and interactions by checking its CapabilityStatement at the designated `/metadata` endpoint. If the directory does not meet these requirements, the client will log an error and skip the update process for that directory. Only directories that pass this validation will be polled as they support the necessary operations for mCSD.
 
-
-## mCSD FHIR API 
+## mCSD FHIR API
 
 The system exposes a FHIR API that adheres to the mCSD specification, allowing clients to perform CRUD operations on supported resources. The API supports standard HTTP methods such as GET, POST, PUT, and DELETE, and returns responses in JSON format.
 
 In a nutshell, mCSD is a standardized way to represent and exchange information about healthcare facilities, services, and providers using FHIR resources. It defines specific profiles and search parameters to ensure interoperability between different systems.
 
-
 ```mermaid
 
 flowchart LR
-
     subgraph mCSD_Directory_Server["mCSD Directory (IHE mCSD over FHIR R4B)"]
       FR[(Facility Registry<br>Organization+Location profiles)]
       HWR[(Health Worker Registry<br>Practitioner+PractitionerRole profiles)]
@@ -89,7 +86,4 @@ flowchart LR
       REL --> API2
     end
 
-
 ```
-
-

--- a/example-setup-with-hapi/app.conf
+++ b/example-setup-with-hapi/app.conf
@@ -68,6 +68,7 @@ mtls_client_key_path =
 mtls_server_ca_path_path =
 request_count = 20
 fill_required_fields = False
+check_capability_statement = True
 
 [directory_api]
 directories_provider_url =

--- a/example-setup-with-hapi/app.conf.example
+++ b/example-setup-with-hapi/app.conf.example
@@ -128,3 +128,4 @@ directory_urls_path = directory_urls.json
 timeout = 10
 # Backoff time for the directory api
 backoff = 0.4
+check_capability_statement = False

--- a/tests/services/api/test_fhir_api_service.py
+++ b/tests/services/api/test_fhir_api_service.py
@@ -339,3 +339,38 @@ def test_post_bundle_should_raise_exception_when_json_invalid_and_http_success(
     with pytest.raises(HTTPException) as e:
         fhir_api.post_bundle(mock_bundle_request)
     assert e.value.status_code == 200
+
+@patch(PATCHED_MODULE)
+# @patch("app.services.fhir.capability_statement_validator.is_capability_statement_valid")
+@patch("app.services.api.fhir_api.is_capability_statement_valid")
+def test_update_client_service_check_capability_statement_succeeds(
+    mock_is_valid: MagicMock,
+    mock_response: MagicMock,
+    fhir_api: FhirApi,
+) -> None:
+    mock_request = MagicMock()
+    mock_request.status_code = 200
+    mock_request.json.return_value = {}
+    mock_response.return_value = mock_request
+    mock_is_valid.return_value = True
+
+    assert fhir_api.validate_capability_statement() is True
+    mock_is_valid.assert_called_once()
+
+@patch(PATCHED_MODULE)
+@patch("app.services.api.fhir_api.is_capability_statement_valid")
+def test_update_client_service_check_capability_statement_fails(
+    mock_is_valid: MagicMock,
+    mock_response: MagicMock,
+    fhir_api: FhirApi,
+) -> None:
+    mock_request = MagicMock()
+    mock_request.status_code = 500
+    mock_request.json.return_value = {}
+    mock_response.return_value = mock_request
+    mock_is_valid.return_value = False
+
+    with pytest.raises(HTTPException) as e:
+        fhir_api.validate_capability_statement()
+    mock_is_valid.assert_not_called()
+    assert e.value.status_code == 500

--- a/tests/services/directory_provider/test_directory_json_provider.py
+++ b/tests/services/directory_provider/test_directory_json_provider.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 from fastapi import HTTPException
 import pytest
 from app.models.directory.dto import DirectoryDto
@@ -74,3 +75,14 @@ def test_get_one_directory_should_return_none_if_not_found(
 ) -> None:
     with pytest.raises(HTTPException):
         json_provider.get_one_directory("3")
+
+def test_get_should_fail_if_capability_statement_check_enabled_and_invalid(
+    json_provider: DirectoryJsonProvider,
+) -> None:
+    # Simulate the capability statement check failing
+    setattr(json_provider, '_DirectoryJsonProvider__validate_capability_statement', True)
+    setattr(json_provider, 'check_capability_statement', MagicMock(return_value=False))
+    with pytest.raises(HTTPException) as exc_info:
+        json_provider.get_one_directory("2")
+    assert exc_info.value.status_code == 400
+    assert "does not support mCSD requirements" in exc_info.value.detail

--- a/tests/services/fhir/test_capability_statement_validator.py
+++ b/tests/services/fhir/test_capability_statement_validator.py
@@ -1,0 +1,167 @@
+import pytest
+from typing import Any, Dict
+
+from app.services.fhir.capability_statement_validator import is_capability_statement_valid
+
+@pytest.fixture
+def valid_capability_statement() -> Dict[str, Any]:
+    """Valid mCSD CapabilityStatement for testing"""
+    return {
+        "resourceType": "CapabilityStatement",
+        "id": "test-server-capability",
+        "url": "http://localhost/CapabilityStatement/test-server",
+        "version": "v0.0.1",
+        "name": "test-server",
+        "title": "test-server",
+        "status": "active",
+        "date": "2025-10-01T00:00:00+00:00",
+        "publisher": "test",
+        "description": "mcsd-match capability statement",
+        "kind": "instance",
+        "fhirVersion": "4.0.1",
+        "format": ["json"],
+        "rest": [
+            {
+                "mode": "server",
+                "documentation": "Test server supporting mCSD resources",
+                "security": {
+                    "service": [],
+                    "description": "No security implemented"
+                },
+                "interaction": [
+                    {
+                        "code": "transaction",
+                        "documentation": "Supports POST Bundles"
+                    }
+                ],
+                "resource": [
+                    {
+                        "type": "Organization",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "Practitioner",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "PractitionerRole",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "Location",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "HealthcareService",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "OrganizationAffiliation",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    },
+                    {
+                        "type": "Endpoint",
+                        "interaction": [
+                            {"code": "read"},
+                            {"code": "search-type"},
+                            {"code": "history-type"}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+def test_valid_capability_statement_passes(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that a valid mCSD CapabilityStatement passes validation"""
+    assert is_capability_statement_valid(valid_capability_statement) is True
+
+def test_no_rest_section_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that CapabilityStatement without/wrong/empty REST section fails"""
+    valid_capability_statement["rest"][0]["mode"] = "client"
+    assert is_capability_statement_valid(valid_capability_statement) is False
+    valid_capability_statement["rest"] = []
+    assert is_capability_statement_valid(valid_capability_statement) is False
+    del valid_capability_statement["rest"]
+    assert is_capability_statement_valid(valid_capability_statement) is False
+
+
+def test_missing_required_resource_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that missing a required mCSD resource fails validation"""
+    # Remove Organization resource
+    valid_capability_statement["rest"][0]["resource"] = [
+        resource for resource in valid_capability_statement["rest"][0]["resource"]
+        if resource["type"] != "Organization"
+    ]
+    assert is_capability_statement_valid(valid_capability_statement) is False
+
+def test_missing_required_interaction_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that missing required interaction fails validation"""
+    # Remove 'search-type' interaction from Organization
+    org_resource = next(
+        resource for resource in valid_capability_statement["rest"][0]["resource"]
+        if resource["type"] == "Organization"
+    )
+    org_resource["interaction"] = [
+        interaction for interaction in org_resource["interaction"]
+        if interaction["code"] != "search-type"
+    ]
+    assert is_capability_statement_valid(valid_capability_statement) is False
+
+def test_no_resources_section_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that CapabilityStatement without resources section fails"""
+    del valid_capability_statement["rest"][0]["resource"]
+    assert is_capability_statement_valid(valid_capability_statement) is False
+
+def test_empty_resources_section_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that CapabilityStatement with empty resources section fails"""
+    valid_capability_statement["rest"][0]["resource"] = []
+    assert is_capability_statement_valid(valid_capability_statement) is False
+
+def test_resource_without_interactions_fails(
+    valid_capability_statement: Dict[str, Any]
+) -> None:
+    """Test that resource without interactions fails validation"""
+    # Remove interactions from Organization
+    org_resource = next(
+        resource for resource in valid_capability_statement["rest"][0]["resource"]
+        if resource["type"] == "Organization"
+    )
+    del org_resource["interaction"]
+    assert is_capability_statement_valid(valid_capability_statement) is False


### PR DESCRIPTION
Closes #246

How to test: Set up and connect two FHIR servers as supplier directories where one of them does not support all the requiered operations and the other one does support all the needed operations. See how the incomplete one fails to be registered in the app.