### PR TITLE
Small refactor of caching directory provider

### DIFF
--- a/app/services/directory_provider/api_provider.py
+++ b/app/services/directory_provider/api_provider.py
@@ -143,7 +143,7 @@ class DirectoryApiProvider(DirectoryProvider):
             logger.warning(f"Failed to retrieve directory {directory_id}: {e}")
             raise e
 
-    def check_if_directory_is_deleted(self, directory_id: str) -> bool:
+    def directory_is_deleted(self, directory_id: str) -> bool:
         try:
             _org = self.__fhir_api.get_resource_by_id(
                 resource_type="Organization",

--- a/app/services/directory_provider/directory_provider.py
+++ b/app/services/directory_provider/directory_provider.py
@@ -46,6 +46,15 @@ class DirectoryProvider(ABC):
         """
         pass
 
+    @abc.abstractmethod
+    def directory_is_deleted(self, directory_id: str) -> bool:
+        """
+        Checks if a directory is marked as deleted.
+        Default implementation always returns False.
+        Override in subclasses if deletion tracking is supported.
+        """
+        return False
+
     @staticmethod
     def check_capability_statement(dir_dto: DirectoryDto) -> bool:
         """

--- a/app/services/directory_provider/factory.py
+++ b/app/services/directory_provider/factory.py
@@ -58,7 +58,7 @@ class DirectoryProviderFactory:
             )
             directory_cache_service = DirectoryCacheService(self.__db)
             return CachingDirectoryProvider(
-                directory_provider=directory_api_provider,
+                inner_directory_provider=directory_api_provider,
                 directory_cache_service=directory_cache_service,
                 validate_capability_statement=self.__mcsd_config.check_capability_statement,
             )

--- a/app/services/directory_provider/json_provider.py
+++ b/app/services/directory_provider/json_provider.py
@@ -10,6 +10,7 @@ class DirectoryJsonProvider(DirectoryProvider):
     """
     Service to manage directories from a JSON data source.
     """
+
     directory_urls: List[DirectoryDto]
 
     def __init__(self, directories_json_data: List[DirectoryDto], ignored_directory_service: IgnoredDirectoryService, validate_capability_statement: bool = False) -> None:
@@ -52,3 +53,6 @@ class DirectoryJsonProvider(DirectoryProvider):
                 detail=f"Directory {directory.id} at {directory.endpoint} does not support mCSD requirements",
             )
         return directory
+
+    def directory_is_deleted(self, directory_id: str) -> bool:
+        return False

--- a/app/services/update/update_client_service.py
+++ b/app/services/update/update_client_service.py
@@ -198,7 +198,7 @@ class UpdateClientService:
                 lock.release()
         else:
             return {
-                "message": f"cannot perform uptate, {directory.id} currently in the background"
+                "message": f"cannot perform update, {directory.id} is currently locked",
             }
 
         return {

--- a/tests/services/directory_provider/test_directory_provider.py
+++ b/tests/services/directory_provider/test_directory_provider.py
@@ -10,7 +10,7 @@ class MockDirectoryProvider(DirectoryProvider):
 
     def get_all_directories(self, include_ignored: bool = False) -> List[DirectoryDto]:
         return self.directories
-    
+
     def get_all_directories_include_ignored(self, include_ignored_ids: List[str]) -> List[DirectoryDto]:
         return self.directories
 
@@ -19,6 +19,12 @@ class MockDirectoryProvider(DirectoryProvider):
         if directory is None:
             raise ValueError(f"Directory with ID '{directory_id}' not found.")
         return directory
+
+    def directory_is_deleted(self, directory_id: str) -> bool:
+        directory =  next((s for s in self.directories if s.id == directory_id), None)
+        if directory is None:
+            raise ValueError(f"Directory with ID '{directory_id}' not found.")
+        return directory.is_deleted
 
 
 @pytest.fixture


### PR DESCRIPTION
Now the caching provider can wrap any other kind of provider, not only the API provider.

Also changed the name a bit to give clarity we are working with a wrapped object (__inner)