### PR TITLE
Fixes update bugs.

### DIFF
--- a/app.test.conf
+++ b/app.test.conf
@@ -37,7 +37,7 @@ service_name =
 tracer_name =
 
 [stats]
-enabled = False
+enabled = True
 host =
 port = 0
 module_name = "test_stats"

--- a/app/models/directory/dto.py
+++ b/app/models/directory/dto.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 
 class DirectoryDto(BaseModel):
     id: str
-    ura: str | None = None
+    ura: str
     endpoint_address: str
     deleted_at: datetime | None = None
     is_ignored: bool = False

--- a/app/routers/directory_router.py
+++ b/app/routers/directory_router.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/directory", tags=["Directory"])
 
-@router.get("/health", response_model=dict[str, Any], description="Check the health of the directory services")
+@router.get("/health", response_model=dict[str, Any], description="Checks the health of all directories based on their last successful sync time.")
 def directory_health(
     info_service: DirectoryInfoService = Depends(get_directory_info_service),
 ) -> Dict[str, Any]:

--- a/app/services/api/directory_api_service.py
+++ b/app/services/api/directory_api_service.py
@@ -10,6 +10,7 @@ from fhir.resources.R4B.organization import Organization
 from fhir.resources.R4B.endpoint import Endpoint
 from fhir.resources.R4B.reference import Reference
 from app.services.fhir.references.reference_misc import build_node_reference
+from app.services.fhir.utils import get_ura_from_organization
 
 logger = logging.getLogger(__name__)
 
@@ -103,6 +104,7 @@ class DirectoryApiService:
                         DirectoryDto(
                             id=resource.id,
                             endpoint_address=endpoint_address,
+                            ura=get_ura_from_organization(resource),
                         )
                     )
             return orgs

--- a/app/services/directory_provider/capability_provider.py
+++ b/app/services/directory_provider/capability_provider.py
@@ -38,14 +38,13 @@ class CapabilityProvider(DirectoryProvider):
 
         return dirs
 
-    def get_one_directory(self, directory_id: str) -> DirectoryDto|None:
+    def get_one_directory(self, directory_id: str) -> DirectoryDto:
         the_dir = self.__inner.get_one_directory(directory_id)
-        if the_dir is None:
-            return None
 
         dirs = self.filter_on_capability([the_dir])
         if not dirs or len(dirs) == 0:
-            return None
+            logger.error(f"Requested directory {directory_id} does not meet capability requirements")
+            raise Exception(f"Requested directory {directory_id} does not meet capability requirements")
 
         return dirs[0]
 

--- a/app/services/directory_provider/db_provider.py
+++ b/app/services/directory_provider/db_provider.py
@@ -1,0 +1,103 @@
+import logging
+from typing import List
+
+from fastapi import HTTPException
+from app.models.directory.dto import DirectoryDto
+from app.services.directory_provider.directory_provider import DirectoryProvider
+from app.services.entity.directory_info_service import DirectoryInfoService
+
+logger = logging.getLogger(__name__)
+
+
+class DbProvider(DirectoryProvider):
+    """
+    Service to manage directories with database persistence.
+    """
+
+    def __init__(
+        self,
+        inner: DirectoryProvider,
+        directory_info_service: DirectoryInfoService,
+    ) -> None:
+        self.__inner = inner  # Fetch and Filter providers
+        self.__directory_info_service = directory_info_service  # Caching in DB
+
+    def get_all_directories(self, include_ignored: bool = False) -> List[DirectoryDto]:
+        try:
+            dirs = self.__inner.get_all_directories(include_ignored)
+        except Exception as e:
+            logger.error(f"Error fetching directories: {e}")
+            return self.__directory_info_service.get_all(
+                include_ignored=include_ignored
+            )
+
+        # Check for deleted directories
+        self._check_and_set_if_deleted(dirs)
+
+        return self._update_directories_in_db(dirs)
+
+    def get_all_directories_include_ignored_ids(
+        self, include_ignored_ids: List[str]
+    ) -> List[DirectoryDto]:
+        try:
+            dirs = self.__inner.get_all_directories_include_ignored_ids(
+                include_ignored_ids
+            )
+        except Exception as e:
+            logger.error(f"Error fetching directories: {e}")
+            return self.__directory_info_service.get_all_including_ignored_ids(
+                include_ignored_ids=include_ignored_ids
+            )
+
+        # Check for deleted directories
+        self._check_and_set_if_deleted(dirs)
+
+        return self._update_directories_in_db(dirs)
+
+    def get_one_directory(self, directory_id: str) -> DirectoryDto:
+        try:
+            dir_dto = self.__inner.get_one_directory(directory_id)
+        except Exception as e:
+            logger.error(f"Error fetching directory with ID '{directory_id}': {e}")
+            self._check_and_set_if_deleted(
+                [DirectoryDto(id=directory_id, ura="", endpoint_address="")]
+            )
+            dir_dto = None
+        try:
+            db_dir = self.__directory_info_service.get_one_by_id(directory_id)
+        except Exception:
+            logger.info(f"Directory with ID '{directory_id}' not found in DB.")
+            if dir_dto is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Directory with ID '{directory_id}' could not be fetched from provider or found in DB.",
+                )
+        return db_dir
+
+    def _update_directories_in_db(self, dirs: List[DirectoryDto]) -> List[DirectoryDto]:
+        """
+        Updates or inserts the fetched directories into the database.
+        """
+        updated_dirs = []
+        for dir_dto in dirs:
+            updated_dir = self.__directory_info_service.create_or_update(
+                directory_id=dir_dto.id,
+                endpoint_address=dir_dto.endpoint_address,
+                ura=dir_dto.ura,
+            )
+            updated_dirs.append(updated_dir)
+
+        return updated_dirs
+
+    def _check_and_set_if_deleted(self, dirs: List[DirectoryDto]) -> None:
+        """
+        If a directory exists in the database but not in the fetched list, check if its deleted
+        """
+        try:
+            for dir_dto in dirs:
+                if not self.__directory_info_service.exists(dir_dto.id):
+                    continue  # Not in DB so its new
+                if self.__inner.is_deleted(dir_dto):
+                    self.__directory_info_service.set_deleted_at(dir_dto.id)
+        except Exception as e:
+            logger.error(f"Error in checking whether directories are deleted: {e}")

--- a/app/services/directory_provider/directory_provider.py
+++ b/app/services/directory_provider/directory_provider.py
@@ -38,7 +38,7 @@ class DirectoryProvider(ABC):
         pass
 
     @abc.abstractmethod
-    def get_one_directory(self, directory_id: str) -> DirectoryDto|None:
+    def get_one_directory(self, directory_id: str) -> DirectoryDto:
         """
         Returns a specific directory by their unique identifier or raises Exception if the directory provider could not be reached.
         """

--- a/app/services/directory_provider/fhir_provider.py
+++ b/app/services/directory_provider/fhir_provider.py
@@ -1,7 +1,6 @@
 import logging
 from typing import List
 
-from fastapi import HTTPException
 from app.models.directory.dto import DirectoryDto
 from app.services.entity.directory_info_service import DirectoryInfoService
 from app.services.api.directory_api_service import (
@@ -20,7 +19,6 @@ class FhirDirectoryProvider(DirectoryProvider):
         self,
         api_provider: DirectoryApiService,
         directory_info_service: DirectoryInfoService,
-        validate_capability_statement: bool = False,
     ) -> None:
         # Api provider to fetch directories from FHIR server
         self.__api_provider = api_provider
@@ -55,15 +53,11 @@ class FhirDirectoryProvider(DirectoryProvider):
 
         return dirs
 
-    def get_one_directory(self, directory_id: str) -> DirectoryDto|None:
+    def get_one_directory(self, directory_id: str) -> DirectoryDto:
         """
         Returns a specific directory by their unique identifier
         """
-        try:
-            directory = self.__api_provider.fetch_one_directory(directory_id)
-        except HTTPException:
-            logger.warning(f"Fetching directory with ID '{directory_id}' from FHIR provider failed.")
-            return None
+        directory = self.__api_provider.fetch_one_directory(directory_id)
 
         return directory
 

--- a/app/services/directory_provider/json_provider.py
+++ b/app/services/directory_provider/json_provider.py
@@ -37,9 +37,11 @@ class DirectoryJsonProvider(DirectoryProvider):
 
         return return_dirs
 
-    def get_one_directory(self, directory_id: str) -> DirectoryDto|None:
-        return next((s for s in self.__directories if s.id == directory_id), None)
-
+    def get_one_directory(self, directory_id: str) -> DirectoryDto:
+        directory = next((s for s in self.__directories if s.id == directory_id), None)
+        if not directory:
+            raise ValueError(f"Directory with id {directory_id} not found in JSON data source.")
+        return directory
 
     @staticmethod
     def _read_directories_file(directory_urls_path: str) -> List[DirectoryDto]:

--- a/tests/services/api/conftest.py
+++ b/tests/services/api/conftest.py
@@ -1,3 +1,8 @@
+import os
+
+if os.getenv("APP_ENV") is None:
+    os.environ["APP_ENV"] = "test" # noqa
+
 from typing import Any, Dict, Final
 import pytest
 
@@ -11,6 +16,7 @@ from app.services.api.authenticators.azure_oauth2_authenticator import (
     AzureOAuth2Authenticator,
 )
 from app.services.api.fhir_api import FhirApi
+
 
 config: Final[Config] = get_config()
 

--- a/tests/services/directory_provider/test_db_provider.py
+++ b/tests/services/directory_provider/test_db_provider.py
@@ -1,0 +1,263 @@
+from unittest.mock import MagicMock
+import pytest
+from fastapi import HTTPException
+
+from app.models.directory.dto import DirectoryDto
+from app.services.directory_provider.db_provider import DbProvider
+from app.services.directory_provider.directory_provider import DirectoryProvider
+from app.services.entity.directory_info_service import DirectoryInfoService
+
+
+def _dto(
+    id_: str, ura: str = "12345678", endpoint_address: str = "http://example.com"
+) -> DirectoryDto:
+    return DirectoryDto(id=id_, ura=ura, endpoint_address=endpoint_address)
+
+
+@pytest.fixture
+def inner_provider() -> MagicMock:
+    return MagicMock(spec=DirectoryProvider)
+
+
+@pytest.fixture
+def directory_info_service() -> MagicMock:
+    return MagicMock(spec=DirectoryInfoService)
+
+
+@pytest.fixture
+def db_provider(
+    inner_provider: MagicMock, directory_info_service: MagicMock
+) -> DbProvider:
+    return DbProvider(
+        inner=inner_provider, directory_info_service=directory_info_service
+    )
+
+
+def test_get_all_directories_success(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("dir_1"), _dto("dir_2")]
+    inner_provider.get_all_directories.return_value = dirs
+    directory_info_service.exists.return_value = False
+    directory_info_service.create_or_update.side_effect = (
+        lambda directory_id, endpoint_address, ura: DirectoryDto(
+            id=directory_id, ura=ura, endpoint_address=endpoint_address
+        )
+    )
+
+    result = db_provider.get_all_directories(include_ignored=False)
+
+    assert len(result) == 2
+    assert result[0].id == "dir_1"
+    assert result[1].id == "dir_2"
+    inner_provider.get_all_directories.assert_called_once_with(False)
+    assert directory_info_service.create_or_update.call_count == 2
+
+
+def test_get_all_directories_fallback_on_error(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    inner_provider.get_all_directories.side_effect = Exception("Provider error")
+    cached_dirs = [_dto("cached_1"), _dto("cached_2")]
+    directory_info_service.get_all.return_value = cached_dirs
+
+    result = db_provider.get_all_directories(include_ignored=True)
+
+    assert len(result) == 2
+    assert result[0].id == "cached_1"
+    assert result[1].id == "cached_2"
+    directory_info_service.get_all.assert_called_once_with(include_ignored=True)
+
+
+def test_get_all_directories_checks_deleted(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("dir_1")]
+    inner_provider.get_all_directories.return_value = dirs
+    directory_info_service.exists.return_value = True
+    inner_provider.is_deleted.return_value = True
+    directory_info_service.create_or_update.side_effect = (
+        lambda directory_id, endpoint_address, ura: DirectoryDto(
+            id=directory_id, ura=ura, endpoint_address=endpoint_address
+        )
+    )
+
+    result = db_provider.get_all_directories()
+
+    assert len(result) == 1
+    directory_info_service.set_deleted_at.assert_called_once_with("dir_1")
+
+
+def test_get_all_directories_include_ignored_ids_success(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("dir_1"), _dto("dir_2")]
+    inner_provider.get_all_directories_include_ignored_ids.return_value = dirs
+    directory_info_service.exists.return_value = False
+    directory_info_service.create_or_update.side_effect = (
+        lambda directory_id, endpoint_address, ura: DirectoryDto(
+            id=directory_id, ura=ura, endpoint_address=endpoint_address
+        )
+    )
+
+    result = db_provider.get_all_directories_include_ignored_ids(
+        include_ignored_ids=["dir_1"]
+    )
+
+    assert len(result) == 2
+    inner_provider.get_all_directories_include_ignored_ids.assert_called_once_with(
+        ["dir_1"]
+    )
+    assert directory_info_service.create_or_update.call_count == 2
+
+
+def test_get_all_directories_include_ignored_ids_fallback_on_error(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    inner_provider.get_all_directories_include_ignored_ids.side_effect = Exception(
+        "Provider error"
+    )
+    cached_dirs = [_dto("cached_1")]
+    directory_info_service.get_all_including_ignored_ids.return_value = cached_dirs
+
+    result = db_provider.get_all_directories_include_ignored_ids(
+        include_ignored_ids=["cached_1"]
+    )
+
+    assert len(result) == 1
+    assert result[0].id == "cached_1"
+    directory_info_service.get_all_including_ignored_ids.assert_called_once_with(
+        include_ignored_ids=["cached_1"]
+    )
+
+
+def test_get_one_directory_success(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    dir_dto = _dto("dir_1")
+    inner_provider.get_one_directory.return_value = dir_dto
+    directory_info_service.get_one_by_id.return_value = dir_dto
+
+    result = db_provider.get_one_directory("dir_1")
+
+    assert result.id == "dir_1"
+    inner_provider.get_one_directory.assert_called_once_with("dir_1")
+    directory_info_service.get_one_by_id.assert_called_once_with("dir_1")
+
+
+def test_get_one_directory_provider_fails_but_db_has_it(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    inner_provider.get_one_directory.side_effect = Exception("Provider error")
+    db_dir = _dto("dir_1")
+    directory_info_service.get_one_by_id.return_value = db_dir
+    directory_info_service.exists.return_value = True
+
+    result = db_provider.get_one_directory("dir_1")
+
+    assert result.id == "dir_1"
+    directory_info_service.get_one_by_id.assert_called_once_with("dir_1")
+
+
+def test_get_one_directory_not_found_anywhere(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    inner_provider.get_one_directory.side_effect = Exception("Provider error")
+    directory_info_service.get_one_by_id.side_effect = Exception("Not in DB")
+
+    with pytest.raises(HTTPException) as exc_info:
+        db_provider.get_one_directory("missing_dir")
+
+    assert exc_info.value.status_code == 404
+    assert "could not be fetched from provider or found in DB" in exc_info.value.detail
+
+
+def test_get_one_directory_checks_if_deleted(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    inner_provider.get_one_directory.side_effect = Exception("Provider error")
+    directory_info_service.exists.return_value = True
+    inner_provider.is_deleted.return_value = True
+    db_dir = _dto("dir_1")
+    directory_info_service.get_one_by_id.return_value = db_dir
+
+    result = db_provider.get_one_directory("dir_1")
+
+    assert result.id == "dir_1"
+    directory_info_service.set_deleted_at.assert_called_once_with("dir_1")
+
+
+def test_update_directories_in_db(
+    db_provider: DbProvider,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("dir_1"), _dto("dir_2")]
+    directory_info_service.create_or_update.side_effect = (
+        lambda directory_id, endpoint_address, ura: DirectoryDto(
+            id=directory_id, ura=ura, endpoint_address=endpoint_address
+        )
+    )
+
+    result = db_provider._update_directories_in_db(dirs)
+
+    assert len(result) == 2
+    assert result[0].id == "dir_1"
+    assert result[1].id == "dir_2"
+    assert directory_info_service.create_or_update.call_count == 2
+
+
+def test_check_and_set_if_deleted_skips_new_directories(
+    db_provider: DbProvider,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("new_dir")]
+    directory_info_service.exists.return_value = False
+
+    db_provider._check_and_set_if_deleted(dirs)
+
+    directory_info_service.set_deleted_at.assert_not_called()
+
+
+def test_check_and_set_if_deleted_marks_deleted_directories(
+    db_provider: DbProvider,
+    inner_provider: MagicMock,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("existing_dir")]
+    directory_info_service.exists.return_value = True
+    inner_provider.is_deleted.return_value = True
+
+    db_provider._check_and_set_if_deleted(dirs)
+
+    directory_info_service.set_deleted_at.assert_called_once_with("existing_dir")
+
+
+def test_check_and_set_if_deleted_handles_errors(
+    db_provider: DbProvider,
+    directory_info_service: MagicMock,
+) -> None:
+    dirs = [_dto("dir_1")]
+    directory_info_service.exists.side_effect = Exception("DB error")
+
+    # Should not raise exception
+    db_provider._check_and_set_if_deleted(dirs)
+
+    directory_info_service.set_deleted_at.assert_not_called()

--- a/tests/services/directory_provider/test_directory_api_provider.py
+++ b/tests/services/directory_provider/test_directory_api_provider.py
@@ -44,9 +44,13 @@ def ignored_dirs() -> list[DirectoryDto]:
     return [_dto("b")]
 
 
-def test_get_all_directories_filters_ignored(provider: DirectoryProvider, api_provider: MagicMock,
-                                             info_service: MagicMock, sample_dirs: List[DirectoryDto],
-                                             ignored_dirs: List[str]) -> None:
+def test_get_all_directories_filters_ignored(
+    provider: DirectoryProvider,
+    api_provider: MagicMock,
+    info_service: MagicMock,
+    sample_dirs: List[DirectoryDto],
+    ignored_dirs: List[str],
+) -> None:
     api_provider.fetch_directories.return_value = sample_dirs
     info_service.get_all_ignored.return_value = ignored_dirs
 
@@ -57,22 +61,30 @@ def test_get_all_directories_filters_ignored(provider: DirectoryProvider, api_pr
     info_service.get_all_ignored.assert_called_once()
 
 
-def test_get_all_directories_include_ignored_returns_all(provider: DirectoryProvider, api_provider: MagicMock,
-                                                         info_service: MagicMock, sample_dirs: List[DirectoryDto],
-                                                         ignored_dirs: List[str]) -> None:
+def test_get_all_directories_include_ignored_returns_all(
+    provider: DirectoryProvider,
+    api_provider: MagicMock,
+    info_service: MagicMock,
+    sample_dirs: List[DirectoryDto],
+    ignored_dirs: List[str],
+) -> None:
     api_provider.fetch_directories.return_value = sample_dirs
-    info_service.get_all_ignored.return_value = ignored_dirs  # should be ignored when include_ignored=True
+    info_service.get_all_ignored.return_value = (
+        ignored_dirs  # should be ignored when include_ignored=True
+    )
 
     result = provider.get_all_directories(include_ignored=True)
 
     assert [d.id for d in result] == ["a", "b", "c"]
 
 
-def test_get_all_directories_include_ignored_ids_keeps_requested_ignored(provider: DirectoryProvider,
-                                                                         api_provider: MagicMock,
-                                                                         info_service: MagicMock,
-                                                                         sample_dirs: List[DirectoryDto],
-                                                                         ignored_dirs: List[str]) -> None:
+def test_get_all_directories_include_ignored_ids_keeps_requested_ignored(
+    provider: DirectoryProvider,
+    api_provider: MagicMock,
+    info_service: MagicMock,
+    sample_dirs: List[DirectoryDto],
+    ignored_dirs: List[str],
+) -> None:
     api_provider.fetch_directories.return_value = sample_dirs
     info_service.get_all_ignored.return_value = ignored_dirs
 
@@ -81,11 +93,13 @@ def test_get_all_directories_include_ignored_ids_keeps_requested_ignored(provide
     assert [d.id for d in result] == ["a", "b", "c"]
 
 
-def test_get_all_directories_include_ignored_ids_filters_when_non_empty_list(provider: DirectoryProvider,
-                                                                             api_provider: MagicMock,
-                                                                             info_service: MagicMock,
-                                                                             sample_dirs: List[DirectoryDto],
-                                                                             ignored_dirs: List[str]) -> None:
+def test_get_all_directories_include_ignored_ids_filters_when_non_empty_list(
+    provider: DirectoryProvider,
+    api_provider: MagicMock,
+    info_service: MagicMock,
+    sample_dirs: List[DirectoryDto],
+    ignored_dirs: List[str],
+) -> None:
     api_provider.fetch_directories.return_value = sample_dirs
     info_service.get_all_ignored.return_value = ignored_dirs
 
@@ -94,11 +108,13 @@ def test_get_all_directories_include_ignored_ids_filters_when_non_empty_list(pro
     assert [d.id for d in result] == ["a", "c"]
 
 
-def test_get_all_directories_include_ignored_ids_empty_list_returns_unfiltered(provider: DirectoryProvider,
-                                                                               api_provider: MagicMock,
-                                                                               info_service: MagicMock,
-                                                                               sample_dirs: List[DirectoryDto],
-                                                                               ignored_dirs: List[str]) -> None:
+def test_get_all_directories_include_ignored_ids_empty_list_returns_unfiltered(
+    provider: DirectoryProvider,
+    api_provider: MagicMock,
+    info_service: MagicMock,
+    sample_dirs: List[DirectoryDto],
+    ignored_dirs: List[str],
+) -> None:
     api_provider.fetch_directories.return_value = sample_dirs
     info_service.get_all_ignored.return_value = ignored_dirs
 
@@ -107,7 +123,9 @@ def test_get_all_directories_include_ignored_ids_empty_list_returns_unfiltered(p
     assert [d.id for d in result] == ["a", "b", "c"]
 
 
-def test_get_one_directory_success(provider: DirectoryProvider, api_provider: MagicMock) -> None:
+def test_get_one_directory_success(
+    provider: DirectoryProvider, api_provider: MagicMock
+) -> None:
     d = _dto("x")
     api_provider.fetch_one_directory.return_value = d
 
@@ -116,21 +134,23 @@ def test_get_one_directory_success(provider: DirectoryProvider, api_provider: Ma
     assert result is d
 
 
-def test_get_one_directory_http_exception_returns_none_and_logs(provider: DirectoryProvider, api_provider: MagicMock,
-                                                                caplog: Any) -> None:
-    api_provider.fetch_one_directory.side_effect = HTTPException(status_code=404, detail="Not found")
-
-    with caplog.at_level(logging.WARNING):
-        result = provider.get_one_directory("missing")
-
-    assert result is None
-    assert any(
-        "Fetching directory with ID 'missing' from FHIR provider failed." in rec.message
-        for rec in caplog.records
+def test_get_one_directory_http_exception_returns_none_and_logs(
+    provider: DirectoryProvider, api_provider: MagicMock, caplog: Any
+) -> None:
+    api_provider.fetch_one_directory.side_effect = HTTPException(
+        status_code=404, detail="Not found"
     )
 
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(HTTPException) as exc_info:
+            _result = provider.get_one_directory("missing")
 
-def test_is_deleted_delegates_to_api_provider(provider: DirectoryProvider, api_provider: MagicMock) -> None:
+    assert exc_info.value.status_code == 404
+
+
+def test_is_deleted_delegates_to_api_provider(
+    provider: DirectoryProvider, api_provider: MagicMock
+) -> None:
     dto = _dto("gone")
     api_provider.check_if_directory_is_deleted.return_value = True
 

--- a/tests/services/directory_provider/test_directory_capability_provider.py
+++ b/tests/services/directory_provider/test_directory_capability_provider.py
@@ -80,26 +80,24 @@ def test_get_one_directory_returns_none_if_capability_fails(provider: DirectoryP
 
     monkeypatch.setattr(CapabilityProvider, "check_capability_statement", staticmethod(lambda d: False))
 
-    out = provider.get_one_directory("a")
-    assert out is None
+    with pytest.raises(Exception) as exc_info:
+        _out = provider.get_one_directory("a")
+    assert "Requested directory a does not meet capability requirements" in str(exc_info.value)
     inner_provider.get_one_directory.assert_called_once_with("a")
 
 
 def test_get_one_directory_propagates_none_from_inner(provider: DirectoryProvider, inner_provider: MagicMock, monkeypatch: pytest.MonkeyPatch) -> None:
     inner_provider.get_one_directory.return_value = None
 
-    called = {"n": 0}
     def fake_check(d: DirectoryDto) -> bool:
-        assert d is not None
-        called["n"] += 1
-        return True
+        raise Exception("Dir not exist")
 
     monkeypatch.setattr(CapabilityProvider, "check_capability_statement", staticmethod(fake_check))
 
-    out = provider.get_one_directory("missing")
-    assert out is None
+    with pytest.raises(Exception) as exc_info:
+        _out = provider.get_one_directory("missing")
+    assert "Dir not exist" in str(exc_info.value)
     inner_provider.get_one_directory.assert_called_once_with("missing")
-    assert called["n"] == 0
 
 
 def test_check_capability_statement_success(monkeypatch: pytest.MonkeyPatch, caplog: Any) -> None:

--- a/tests/services/directory_provider/test_directory_json_provider.py
+++ b/tests/services/directory_provider/test_directory_json_provider.py
@@ -33,7 +33,7 @@ def test_get_all_dirs(
     json_provider: DirectoryJsonProvider,
     dir_info_service: DirectoryInfoService,
 ) -> None:
-    dir_info_service.get_all_ignored = MagicMock(return_value=[DirectoryDto(id="dir_3", endpoint_address="http://example.com/1")])   # type: ignore
+    dir_info_service.get_all_ignored = MagicMock(return_value=[DirectoryDto(id="dir_3", ura="12345678",endpoint_address="http://example.com/1")])   # type: ignore
 
     # Test without ignored directories
     result = json_provider.get_all_directories(include_ignored=False)
@@ -95,5 +95,6 @@ def test_get_one_directory_should_return_correct_directory(
 def test_get_one_directory_should_return_none_if_not_found(
     json_provider: DirectoryJsonProvider,
 ) -> None:
-    result = json_provider.get_one_directory("dir_not_existing")
-    assert result is None
+    with pytest.raises(Exception) as exc_info:
+        _result = json_provider.get_one_directory("dir_not_existing")
+    assert "Directory with id dir_not_existing not found" in str(exc_info.value)

--- a/tests/services/entity_services/test_directory_info_service.py
+++ b/tests/services/entity_services/test_directory_info_service.py
@@ -6,208 +6,228 @@ from app.models.directory.dto import DirectoryDto
 from app.services.entity.directory_info_service import DirectoryInfoService
 
 
-class TestDirectoryInfoService:
-    @pytest.fixture
-    def sample_directory_info_ignored(self) -> DirectoryDto:
-        return DirectoryDto(
-            id="test-directory-ignored",
-            ura="87654321",
-            endpoint_address="https://example.com/fhir",
-            failed_sync_count=2,
-            failed_attempts=1,
-            last_success_sync=datetime.now() - timedelta(hours=2),
-            is_ignored=True,
-        )
+@pytest.fixture
+def sample_directory_info_ignored() -> DirectoryDto:
+    return DirectoryDto(
+        id="test-directory-ignored",
+        ura="87654321",
+        endpoint_address="https://example.com/fhir",
+        failed_sync_count=2,
+        failed_attempts=1,
+        last_success_sync=datetime.now() - timedelta(hours=2),
+        is_ignored=True,
+    )
 
-    @pytest.fixture
-    def sample_directory_info_deleted(self) -> DirectoryDto:
-        return DirectoryDto(
-            id="test-directory-deleted",
-            ura="87654321",
-            endpoint_address="https://example.com/fhir",
-            last_success_sync=datetime.now() - timedelta(hours=1),
-            deleted_at=datetime.now(),
-        )
+@pytest.fixture
+def sample_directory_info_deleted() -> DirectoryDto:
+    return DirectoryDto(
+        id="test-directory-deleted",
+        ura="87654321",
+        endpoint_address="https://example.com/fhir",
+        last_success_sync=datetime.now() - timedelta(hours=1),
+        deleted_at=datetime.now(),
+    )
 
-    def test_update_directory_info(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        """Test updating a directory info entry."""
-        with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
-            directory_info_service.get_one_by_id("test-directory-1")
+def test_create_directory_info(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    """Test updating a directory info entry."""
+    with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
+        directory_info_service.get_one_by_id("test-directory-1")
 
-        updated = directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
+    created = directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    assert created.id == "test-directory-1"
+    assert created.endpoint_address == "https://example.com/fhir"
+    assert not created.is_ignored
 
-        assert updated.id == "test-directory-1"
-        assert updated.endpoint_address == "https://example.com/fhir"
-        assert not updated.is_ignored
+    result = directory_info_service.get_one_by_id("test-directory-1")
+    assert result is not None
+    assert result.id == "test-directory-1"
+    assert result.endpoint_address == "https://example.com/fhir"
+    assert not result.is_ignored
 
-        updated_again = directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/updated-fhir", is_ignored=True)
-        assert updated_again.id == "test-directory-1"
-        assert updated_again.endpoint_address == "https://example.com/updated-fhir"
-        assert updated_again.is_ignored
+    with pytest.raises(HTTPException, match="Directory with ID test-directory-1 already exists"):
+        directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
-        assert retrieved.id == "test-directory-1"
 
-    def test_delete_directory_info(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
+def test_update_directory_info(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    """Test updating a directory info entry."""
+    with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
+        directory_info_service.get_one_by_id("test-directory-1")
+
+    with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
         directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
-        assert retrieved is not None
+    to_be_updated = directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
 
-        directory_info_service.delete("test-directory-1")
+    assert to_be_updated.id == "test-directory-1"
+    assert to_be_updated.endpoint_address == "https://example.com/fhir"
+    assert not to_be_updated.is_ignored
 
-        with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
-            directory_info_service.get_one_by_id("test-directory-1")
+    updated_again = directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/updated-fhir", is_ignored=True)
+    assert updated_again.id == "test-directory-1"
+    assert updated_again.endpoint_address == "https://example.com/updated-fhir"
+    assert updated_again.is_ignored
 
-    def test_get_one_by_id(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
+    assert retrieved.id == "test-directory-1"
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
+def test_delete_directory_info(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
 
-        assert retrieved.id == "test-directory-1"
-        assert retrieved.endpoint_address == "https://example.com/fhir"
-        assert not retrieved.is_ignored
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
+    assert retrieved is not None
 
-    def test_get_one_by_id_not_found(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        with pytest.raises(HTTPException, match="Directory with ID nonexistent not found"):
-            directory_info_service.get_one_by_id("nonexistent")
+    directory_info_service.delete("test-directory-1")
 
-    def test_get_all(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
-        directory_info_service.update(directory_id="test-directory-ignored", endpoint_address="https://example.com/ignored-fhir", is_ignored=True)
-        directory_info_service.update(directory_id="test-directory-deleted", endpoint_address="https://example.com/deleted-fhir", deleted_at=datetime.now()-timedelta(days=1))
+    with pytest.raises(HTTPException, match="Directory with ID test-directory-1 not found"):
+        directory_info_service.get_one_by_id("test-directory-1")
 
-        all_entries = directory_info_service.get_all()
-        assert len(all_entries) == 1
-        assert all_entries[0].id == "test-directory-1"
+def test_get_one_by_id(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
 
-        all_with_ignored = directory_info_service.get_all(include_ignored=True)
-        assert len(all_with_ignored) == 2
-        ids = {entry.id for entry in all_with_ignored}
-        assert ids == {"test-directory-1", "test-directory-ignored"}
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
 
-        all_with_deleted = directory_info_service.get_all(include_deleted=True)
-        assert len(all_with_deleted) == 2
-        ids = {entry.id for entry in all_with_deleted}
-        assert ids == {"test-directory-1", "test-directory-deleted"}
+    assert retrieved.id == "test-directory-1"
+    assert retrieved.endpoint_address == "https://example.com/fhir"
+    assert not retrieved.is_ignored
 
-        all_with_both = directory_info_service.get_all(include_ignored=True, include_deleted=True)
-        assert len(all_with_both) == 3
-        ids = {entry.id for entry in all_with_both}
-        assert ids == {"test-directory-1", "test-directory-ignored", "test-directory-deleted"}
+def test_get_one_by_id_not_found(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    with pytest.raises(HTTPException, match="Directory with ID nonexistent not found"):
+        directory_info_service.get_one_by_id("nonexistent")
 
-        entries = directory_info_service.get_all_including_ignored_ids(
-            include_ignored_ids=["test-directory-ignored"]
-        )
-        assert len(entries) == 2  # active + the specifically included ignored one
-        ids = {entry.id for entry in entries}
-        assert ids == {"test-directory-1", "test-directory-ignored"}
+def test_get_all(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.create(directory_id="test-directory-ignored", endpoint_address="https://example.com/ignored-fhir", ura="12345678")
+    directory_info_service.create(directory_id="test-directory-deleted", endpoint_address="https://example.com/deleted-fhir", ura="12345678")
 
-        entries_with_deleted = directory_info_service.get_all_including_ignored_ids(
-            include_ignored_ids=["test-directory-ignored"],
-            include_deleted=True
-        )
-        assert len(entries_with_deleted) == 3
-        ids = {entry.id for entry in entries_with_deleted}
-        assert ids == {"test-directory-1", "test-directory-ignored", "test-directory-deleted"}
+    directory_info_service.update("test-directory-ignored", is_ignored=True)
+    directory_info_service.update("test-directory-deleted", deleted_at=datetime.now()-timedelta(days=1))
 
-        deleted_entries = directory_info_service.get_all_deleted()
-        assert len(deleted_entries) == 1
-        assert deleted_entries[0].id == "test-directory-deleted"
+    all_entries = directory_info_service.get_all()
+    assert len(all_entries) == 1
+    assert all_entries[0].id == "test-directory-1"
 
-        ignored_entries = directory_info_service.get_all_ignored()
-        assert len(ignored_entries) == 1
-        assert ignored_entries[0].id == "test-directory-ignored"
+    all_with_ignored = directory_info_service.get_all(include_ignored=True)
+    assert len(all_with_ignored) == 2
+    ids = {entry.id for entry in all_with_ignored}
+    assert ids == {"test-directory-1", "test-directory-ignored"}
 
-    def test_set_ignored_status(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
+    all_with_deleted = directory_info_service.get_all(include_deleted=True)
+    assert len(all_with_deleted) == 2
+    ids = {entry.id for entry in all_with_deleted}
+    assert ids == {"test-directory-1", "test-directory-deleted"}
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
-        assert retrieved.is_ignored is False
+    all_with_both = directory_info_service.get_all(include_ignored=True, include_deleted=True)
+    assert len(all_with_both) == 3
+    ids = {entry.id for entry in all_with_both}
+    assert ids == {"test-directory-1", "test-directory-ignored", "test-directory-deleted"}
 
-        directory_info_service.set_ignored_status("test-directory-1", ignored=True)
+    entries = directory_info_service.get_all_including_ignored_ids(
+        include_ignored_ids=["test-directory-ignored"]
+    )
+    assert len(entries) == 2  # active + the specifically included ignored one
+    ids = {entry.id for entry in entries}
+    assert ids == {"test-directory-1", "test-directory-ignored"}
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
-        assert retrieved.is_ignored is True
+    entries_with_deleted = directory_info_service.get_all_including_ignored_ids(
+        include_ignored_ids=["test-directory-ignored"],
+        include_deleted=True
+    )
+    assert len(entries_with_deleted) == 3
+    ids = {entry.id for entry in entries_with_deleted}
+    assert ids == {"test-directory-1", "test-directory-ignored", "test-directory-deleted"}
 
-        directory_info_service.set_ignored_status("test-directory-1", ignored=False)
+    deleted_entries = directory_info_service.get_all_deleted()
+    assert len(deleted_entries) == 1
+    assert deleted_entries[0].id == "test-directory-deleted"
 
-        retrieved = directory_info_service.get_one_by_id("test-directory-1")
-        assert retrieved.is_ignored is False
+    ignored_entries = directory_info_service.get_all_ignored()
+    assert len(ignored_entries) == 1
+    assert ignored_entries[0].id == "test-directory-ignored"
 
-    def test_set_ignored_status_not_found(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        with pytest.raises(HTTPException, match="Directory with ID nonexistent not found"):
-            directory_info_service.set_ignored_status("nonexistent", ignored=True)
+def test_set_ignored_status(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
 
-    def test_health_check_all_healthy(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", last_success_sync = datetime.now() - timedelta(minutes=30), endpoint_address="https://example.com/fhir")
-        assert directory_info_service.health_check() is True
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
+    assert retrieved.is_ignored is False
 
-    def test_health_check_unhealthy_no_sync(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
-        assert directory_info_service.health_check() is False
+    directory_info_service.set_ignored_status("test-directory-1", ignored=True)
 
-    def test_health_check_unhealthy_stale(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", last_success_sync = datetime.now() - timedelta(hours=2))
-        assert directory_info_service.health_check() is False
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
+    assert retrieved.is_ignored is True
 
-    def test_health_check_mixed(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", last_success_sync = datetime.now() - timedelta(minutes=30))
-        directory_info_service.update(directory_id="unhealthy-dir", endpoint_address="https://example.com/fhir",
-            last_success_sync=None)
-        assert directory_info_service.health_check() is False
+    directory_info_service.set_ignored_status("test-directory-1", ignored=False)
 
-    def test_get_prometheus_metrics(
-        self,
-        directory_info_service: DirectoryInfoService,
-    ) -> None:
-        directory_info_service.update(directory_id="test-directory-1", endpoint_address="https://example.com/fhir")
-        directory_info_service.update(directory_id="test-directory-ignored", endpoint_address="https://example.com/ignored-fhir", is_ignored=True)
+    retrieved = directory_info_service.get_one_by_id("test-directory-1")
+    assert retrieved.is_ignored is False
 
-        metrics = directory_info_service.get_prometheus_metrics()
+def test_set_ignored_status_not_found(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    with pytest.raises(HTTPException, match="Directory with ID nonexistent not found"):
+        directory_info_service.set_ignored_status("nonexistent", ignored=True)
 
-        assert len(metrics) > 0
-        assert any("directory_failed_sync_total" in line for line in metrics)
-        assert any("directory_failed_attempts" in line for line in metrics)
-        assert any("directory_last_success_sync" in line for line in metrics)
-        assert any("directory_is_ignored" in line for line in metrics)
+def test_health_check_all_healthy(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.update(directory_id="test-directory-1", last_success_sync = datetime.now() - timedelta(minutes=30))
+    assert directory_info_service.health_check() is True
 
-        assert not any("test-directory-ignored" in line for line in metrics)
+def test_health_check_unhealthy_no_sync(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    assert directory_info_service.health_check() is False
 
-        failed_sync_lines = [line for line in metrics if "directory_failed_sync_total{directory_id=" in line]
-        assert len(failed_sync_lines) == 1
-        assert "test-directory-1" in failed_sync_lines[0]
-        assert "0" in failed_sync_lines[0]
+def test_health_check_unhealthy_stale(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.update(directory_id="test-directory-1", last_success_sync = datetime.now() - timedelta(hours=2))
+    assert directory_info_service.health_check() is False
+
+def test_health_check_mixed(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.update(directory_id="test-directory-1", last_success_sync = datetime.now() - timedelta(minutes=30))
+    assert directory_info_service.health_check() is True
+    directory_info_service.create(directory_id="unhealthy-dir", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.update(directory_id="unhealthy-dir", last_success_sync=None)
+    assert directory_info_service.health_check() is False
+
+def test_get_prometheus_metrics(
+    directory_info_service: DirectoryInfoService,
+) -> None:
+    directory_info_service.create(directory_id="test-directory-1", endpoint_address="https://example.com/fhir", ura="12345678")
+    directory_info_service.create(directory_id="test-directory-ignored", endpoint_address="https://example.com/ignored-fhir", ura="12345678")
+    directory_info_service.update(directory_id="test-directory-ignored", is_ignored=True)
+
+    metrics = directory_info_service.get_prometheus_metrics()
+
+    assert len(metrics) > 0
+    assert any("directory_failed_sync_total" in line for line in metrics)
+    assert any("directory_failed_attempts" in line for line in metrics)
+    assert any("directory_last_success_sync" in line for line in metrics)
+    assert any("directory_is_ignored" in line for line in metrics)
+
+    assert not any("test-directory-ignored" in line for line in metrics)
+
+    failed_sync_lines = [line for line in metrics if "directory_failed_sync_total{directory_id=" in line]
+    assert len(failed_sync_lines) == 1
+    assert "test-directory-1" in failed_sync_lines[0]
+    assert "0" in failed_sync_lines[0]


### PR DESCRIPTION
Adds a DbProvider to update or create entries that are retrieved from earlier DirectoryProviders.
Fixes tests.

Fixes for the following bugs:

- [x] https://github.com/minvws/gfmodules-coordination-private/issues/656
- [x] https://github.com/minvws/gfmodules-coordination-private/issues/660